### PR TITLE
[#23] checkstyle 버전 10.2로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 checkstyle {
     maxWarnings = 0 // 규칙이 어긋나는 코드가 하나라도 있을 경우 빌드 fail을 내고 싶다면 이 선언을 추가한다.
     configFile = file("${rootDir}/config/checkstyle/naver-checkstyle-rules.xml")
-    toolVersion = "8.24"  // checkstyle 버전 8.24 이상 선언
+    toolVersion = "10.2"  // checkstyle 버전 8.24 이상 선언
 }
 
 ext {


### PR DESCRIPTION
## 개요
- checkstyle 버전 10.2로 변경

## 추가기능
- 최신 자바 문법도 분석 가능

## 기타
- fix #23 
