### PR TITLE
feat: 상영관 추가 구현

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/RestApiControllerAdvice.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/RestApiControllerAdvice.java
@@ -1,0 +1,25 @@
+package prgrms.marco.be02marbox.domain.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class RestApiControllerAdvice {
+	@ExceptionHandler({
+		EntityNotFoundException.class
+	})
+	public ResponseEntity<String> notFoundHandler(Exception exception) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+	}
+
+	@ExceptionHandler({
+		Exception.class
+	})
+	public ResponseEntity<String> internalServerErrorHandler(Exception exception) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(exception.getMessage());
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/Seat.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/Seat.java
@@ -1,5 +1,7 @@
 package prgrms.marco.be02marbox.domain.theater;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -9,6 +11,9 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 @Entity
 @Table(name = "seat")
@@ -20,7 +25,7 @@ public class Seat {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "theater_room_id")
+	@JoinColumn(name = "theater_room_id", nullable = false)
 	private TheaterRoom theaterRoom;
 
 	@Column(name = "rows")
@@ -28,4 +33,57 @@ public class Seat {
 
 	@Column(name = "columns")
 	private Integer column;
+
+	protected Seat() {
+	}
+
+	public void changeTheaterRoom(TheaterRoom theaterRoom) {
+		this.theaterRoom = theaterRoom;
+	}
+
+	public Seat(Integer row, Integer column) {
+		this.row = row;
+		this.column = column;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public TheaterRoom getTheaterRoom() {
+		return theaterRoom;
+	}
+
+	public Integer getRow() {
+		return row;
+	}
+
+	public Integer getColumn() {
+		return column;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		Seat seat = (Seat)obj;
+		return Objects.equals(id, seat.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("row", row)
+			.append("column", column)
+			.toString();
+	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/Theater.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/Theater.java
@@ -24,4 +24,8 @@ public class Theater {
 
 	@Column(name = "name")
 	private String name;
+
+	public Long getId() {
+		return id;
+	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/TheaterRoom.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/TheaterRoom.java
@@ -2,6 +2,7 @@ package prgrms.marco.be02marbox.domain.theater;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -14,10 +15,16 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 @Entity
 @Table(name = "theater_room")
 public class TheaterRoom {
+	private static final String SEATS_NOT_EMPTY_ERR = "좌석 정보를 1개이상 등록해야 합니다.";
 
 	@Id
 	@Column(name = "id")
@@ -26,14 +33,81 @@ public class TheaterRoom {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "theater_id")
+	@NotNull
 	private Theater theater;
 
 	@Column(name = "name")
 	private String name;
 
 	@Column(name = "total_seats")
-	private Long totalSeats;
+	private Integer totalSeats;
 
 	@OneToMany(mappedBy = "theaterRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-	List<Seat> seats = new ArrayList<>();
+	@NotNull
+	@Size(min = 1, message = SEATS_NOT_EMPTY_ERR)
+	private List<Seat> seats = new ArrayList<>();
+
+	protected TheaterRoom() {
+	}
+
+	public TheaterRoom(Theater theater, String name, List<Seat> seats) {
+		this.theater = theater;
+		this.name = name;
+		setSeats(seats);
+		this.totalSeats = seats.size();
+	}
+
+	private void setSeats(List<Seat> seats) {
+		seats.forEach(this::accept);
+		this.seats = seats;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Theater getTheater() {
+		return theater;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Integer getTotalSeats() {
+		return totalSeats;
+	}
+
+	public List<Seat> getSeats() {
+		return seats;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		TheaterRoom that = (TheaterRoom)obj;
+		return id.equals(that.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("name", name)
+			.append("totalSeats", totalSeats)
+			.toString();
+	}
+
+	private void accept(Seat seat) {
+		seat.changeTheaterRoom(this);
+	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/converter/SeatConverter.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/converter/SeatConverter.java
@@ -1,0 +1,14 @@
+package prgrms.marco.be02marbox.domain.theater.converter;
+
+import org.springframework.stereotype.Component;
+
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.dto.SeatRequestDto;
+
+@Component
+public class SeatConverter {
+
+	public Seat convertSeat(SeatRequestDto seatRequestDto) {
+		return new Seat(seatRequestDto.getRow(), seatRequestDto.getCol());
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/SeatRequestDto.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/SeatRequestDto.java
@@ -1,0 +1,49 @@
+package prgrms.marco.be02marbox.domain.theater.dto;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class SeatRequestDto {
+	private int row;
+	private int col;
+
+	public SeatRequestDto(int row, int col) {
+		this.row = row;
+		this.col = col;
+	}
+
+	public int getRow() {
+		return row;
+	}
+
+	public int getCol() {
+		return col;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		SeatRequestDto that = (SeatRequestDto)obj;
+		return row == that.row && col == that.col;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(row, col);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+			.append("row", row)
+			.append("col", col)
+			.toString();
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/TheaterRoomRequestDto.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/TheaterRoomRequestDto.java
@@ -1,0 +1,49 @@
+package prgrms.marco.be02marbox.domain.theater.dto;
+
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class TheaterRoomRequestDto {
+	@NotNull
+	private Long theaterId;
+	@NotNull
+	private String name;
+	@NotNull
+	@Size(min = 1)
+	private List<SeatRequestDto> seatRequestDtos;
+
+	public TheaterRoomRequestDto(Long theaterId, String name,
+		List<SeatRequestDto> seatRequestDtos) {
+		this.theaterId = theaterId;
+		this.name = name;
+		this.seatRequestDtos = seatRequestDtos;
+	}
+
+	public Long getTheaterId() {
+		return theaterId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public List<SeatRequestDto> getSeatRequestDtos() {
+		return seatRequestDtos;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		TheaterRoomRequestDto that = (TheaterRoomRequestDto)obj;
+		return Objects.equals(theaterId, that.theaterId) && Objects.equals(name, that.name)
+			&& seatRequestDtos.equals(that.seatRequestDtos);
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/repository/SeatRepository.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/repository/SeatRepository.java
@@ -1,8 +1,11 @@
 package prgrms.marco.be02marbox.domain.theater.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import prgrms.marco.be02marbox.domain.theater.Seat;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
+	List<Seat> findByTheaterRoomId(Long theaterRoomId);
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
@@ -1,0 +1,49 @@
+package prgrms.marco.be02marbox.domain.theater.service;
+
+import static java.util.stream.Collectors.*;
+
+import java.util.List;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.springframework.stereotype.Service;
+
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.Theater;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.converter.SeatConverter;
+import prgrms.marco.be02marbox.domain.theater.dto.TheaterRoomRequestDto;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRoomRepository;
+
+@Service
+public class TheaterRoomService {
+
+	private static final String NOT_FOUND_THEATER_ERR = "극장 정보를 조회할 수 없습니다.";
+
+	private final TheaterRoomRepository theaterRoomRepository;
+	private final TheaterRepository theaterRepository;
+	private final SeatConverter seatConverter;
+
+	public TheaterRoomService(TheaterRoomRepository theaterRoomRepository,
+		TheaterRepository theaterRepository,
+		SeatConverter seatConverter) {
+		this.theaterRoomRepository = theaterRoomRepository;
+		this.theaterRepository = theaterRepository;
+		this.seatConverter = seatConverter;
+	}
+
+	public Long save(TheaterRoomRequestDto requestDto) {
+		Theater theater = theaterRepository.findById(requestDto.getTheaterId())
+			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_THEATER_ERR));
+
+		List<Seat> seats = requestDto.getSeatRequestDtos().stream()
+			.distinct()
+			.map(seatConverter::convertSeat)
+			.collect(toList());
+
+		TheaterRoom newTheaterRoom = new TheaterRoom(theater, requestDto.getName(), seats);
+		TheaterRoom savedTheaterRoom = theaterRoomRepository.save(newTheaterRoom);
+		return savedTheaterRoom.getId();
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/TheaterRoomTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/TheaterRoomTest.java
@@ -1,0 +1,49 @@
+package prgrms.marco.be02marbox.domain.theater;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TheaterRoomTest {
+	private static Validator validator;
+
+	@BeforeAll
+	static void setUp() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+
+	@Test
+	@DisplayName("좌석정보(seats)는 1개 이상 등록되어야 한다.")
+	void testValidate_seats() {
+		Theater theater = new Theater();
+		TheaterRoom theaterRoom = new TheaterRoom(theater, "name", new ArrayList<>());
+
+		Set<ConstraintViolation<TheaterRoom>> validate = validator.validate(theaterRoom);
+		assertThat(validate).hasSize(1);
+	}
+
+	@Test
+	@DisplayName("TheaterRoom 생성 성공")
+	void testValidate_success() {
+		Theater theater = new Theater();
+		List<Seat> seats = new ArrayList<>();
+		seats.add(new Seat());
+		seats.add(new Seat());
+		TheaterRoom theaterRoom = new TheaterRoom(theater, "A관", seats);
+
+		Set<ConstraintViolation<TheaterRoom>> validate = validator.validate(theaterRoom);
+		assertThat(validate).isEmpty();
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/repository/TheaterRoomRepositoryTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/repository/TheaterRoomRepositoryTest.java
@@ -1,0 +1,97 @@
+package prgrms.marco.be02marbox.domain.theater.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.Theater;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+
+@DataJpaTest
+class TheaterRoomRepositoryTest {
+
+	@Autowired
+	private TheaterRoomRepository theaterRoomRepository;
+
+	@Autowired
+	private TheaterRepository theaterRepository;
+
+	@Autowired
+	private SeatRepository seatRepository;
+
+	private final Theater theater = new Theater();
+	private TheaterRoom theaterRoom;
+	private List<Seat> seats = new ArrayList<>();
+
+	@BeforeEach
+	void init() {
+		theaterRepository.save(theater);
+		seats.clear();
+		seats.add(new Seat(0, 0));
+		seats.add(new Seat(0, 1));
+		seats.add(new Seat(0, 2));
+		theaterRoom = new TheaterRoom(theater, "A관", seats);
+		theaterRoomRepository.save(theaterRoom);
+	}
+
+	@AfterEach
+	void clear() {
+		theaterRepository.deleteAll();
+		theaterRoomRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("TheaterRoom cascade 저장 성공")
+	void testSave() {
+		List<Seat> findSeats = seatRepository.findAll();
+		Optional<TheaterRoom> findTheaterRoom = theaterRoomRepository.findById(theaterRoom.getId());
+		assertAll(
+			() -> assertThat(findTheaterRoom).isPresent(),
+			() -> {
+				TheaterRoom getTheaterRoom = findTheaterRoom.get();
+				assertThat(getTheaterRoom).isEqualTo(theaterRoom);
+				assertThat(getTheaterRoom.getSeats()).hasSize(seats.size());
+				assertThat(getTheaterRoom.getTotalSeats()).isEqualTo(seats.size());
+			},
+			() -> assertThat(findSeats).hasSize(seats.size()),
+			() -> assertThat(findSeats.get(0).getTheaterRoom().getId()).isEqualTo(theaterRoom.getId())
+		);
+	}
+
+	@Test
+	@DisplayName("TheaterRoom cascade 삭제 성공")
+	void testDelete() {
+		theaterRoomRepository.deleteById(theaterRoom.getId());
+
+		List<Seat> findSeats = seatRepository.findAll();
+		Optional<TheaterRoom> findTheaterRoom = theaterRoomRepository.findById(theaterRoom.getId());
+
+		assertAll(
+			() -> assertThat(findSeats).isEmpty(),
+			() -> assertThat(findTheaterRoom).isEmpty()
+		);
+	}
+
+	@Test
+	@DisplayName("orphanRemoval=true 적용 성공")
+	void testOrphanRemovalTrue() {
+		TheaterRoom findTheaterRoom = theaterRoomRepository.findById(theaterRoom.getId()).get();
+
+		int beforeSize = findTheaterRoom.getTotalSeats();
+		findTheaterRoom.getSeats().remove(0);
+
+		List<Seat> findSeats = seatRepository.findAll();
+		assertThat(findSeats).hasSize(beforeSize - 1);
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
@@ -1,0 +1,98 @@
+package prgrms.marco.be02marbox.domain.theater.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.Theater;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.converter.SeatConverter;
+import prgrms.marco.be02marbox.domain.theater.dto.SeatRequestDto;
+import prgrms.marco.be02marbox.domain.theater.dto.TheaterRoomRequestDto;
+import prgrms.marco.be02marbox.domain.theater.repository.SeatRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRoomRepository;
+
+@DataJpaTest
+@Import({TheaterRoomService.class, SeatConverter.class})
+class TheaterRoomServiceTest {
+
+	@Autowired
+	TheaterRoomService theaterRoomService;
+	@Autowired
+	TheaterRepository theaterRepository;
+	@Autowired
+	TheaterRoomRepository theaterRoomRepository;
+	@Autowired
+	SeatRepository seatRepository;
+
+	private Theater theater = new Theater();
+	private List<SeatRequestDto> seatRequestDtos = new ArrayList<>();
+
+	@BeforeEach
+	void init() {
+		seatRequestDtos.add(new SeatRequestDto(0, 0));
+		theaterRepository.save(theater);
+	}
+
+	@AfterEach
+	void clear() {
+		seatRequestDtos.clear();
+	}
+
+	@Test
+	@DisplayName("새로운 상영관을 추가할 수 있다.")
+	void testSave() {
+		TheaterRoomRequestDto requestDto = new TheaterRoomRequestDto(theater.getId(), "A관", seatRequestDtos);
+		int expectTotalCount = seatRequestDtos.size();
+		Long savedId = theaterRoomService.save(requestDto);
+
+		Optional<TheaterRoom> findTheaterRoom = theaterRoomRepository.findById(savedId);
+		List<Seat> findSeats = seatRepository.findByTheaterRoomId(savedId);
+
+		assertAll(
+			() -> assertThat(findTheaterRoom).isPresent(),
+			() -> assertThat(findSeats).hasSize(expectTotalCount)
+		);
+	}
+
+	@Test
+	@DisplayName("하나의 상영관에는 동일한 row, col을 가진 좌석이 존재할 수 없다.")
+	void testSave_distinct() {
+		seatRequestDtos.add(new SeatRequestDto(0, 1));
+		seatRequestDtos.add(new SeatRequestDto(0, 2));
+		seatRequestDtos.add(new SeatRequestDto(0, 1));
+		seatRequestDtos.add(new SeatRequestDto(0, 2));
+		seatRequestDtos.add(new SeatRequestDto(0, 1));
+		seatRequestDtos.add(new SeatRequestDto(0, 2));
+
+		TheaterRoomRequestDto requestDto = new TheaterRoomRequestDto(theater.getId(), "A관", seatRequestDtos);
+		int expectTotalCount = 3;
+		Long savedId = theaterRoomService.save(requestDto);
+		List<Seat> findSeats = seatRepository.findByTheaterRoomId(savedId);
+
+		assertThat(findSeats).hasSize(expectTotalCount);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 Theater의 요청은 EntityNotFoundException 발생")
+	void testSave_entityNotFoundException() {
+		TheaterRoomRequestDto requestDto = new TheaterRoomRequestDto(-1L, "A관", seatRequestDtos);
+
+		assertThrows(EntityNotFoundException.class, () -> theaterRoomService.save(requestDto));
+	}
+}


### PR DESCRIPTION
## 개요

- 상영관 추가 구현

## 추가기능

- 상영관을 추가할 수 있다.

## 변경사항(Optional)

- TheaterRoom.totalSeats 타입 변경 (Long -> Integer)

## 사용방법(Optional)

- 관리자는 영화관 선택 -> 좌석 선택 후 상영관을 추가할 수 있다.
- 반드시 1개 이상의 좌석정보가 입력되어야 한다.

## 기타
- Controller 미구현