### PR TITLE
[#9] 사용자는 회원가입할 수 있다. 

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/config/WebSecurityConfigure.java
+++ b/src/main/java/prgrms/marco/be02marbox/config/WebSecurityConfigure.java
@@ -1,0 +1,25 @@
+package prgrms.marco.be02marbox.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+			.authorizeRequests()
+			.anyRequest().permitAll()
+			.and()
+
+			.csrf()
+			.disable()
+
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/Role.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/Role.java
@@ -1,5 +1,5 @@
 package prgrms.marco.be02marbox.domain.user;
 
 public enum Role {
-	CUSTOMER, MANAGER, ADMIN
+	ROLE_CUSTOMER, ROLE_ADMIN
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/User.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/User.java
@@ -30,4 +30,18 @@ public class User {
 
 	@Column(name = "name")
 	private String name;
+
+	protected User() {
+	}
+
+	public User(String email, String password, String name, Role role) {
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.role = role;
+	}
+
+	public Long getId() {
+		return id;
+	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/controller/UserController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package prgrms.marco.be02marbox.domain.user.controller;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import prgrms.marco.be02marbox.domain.user.dto.UserSignUpReq;
+import prgrms.marco.be02marbox.domain.user.dto.UserSignUpRes;
+import prgrms.marco.be02marbox.domain.user.service.UserService;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+	private final UserService userService;
+
+	public UserController(UserService userService) {
+		this.userService = userService;
+	}
+
+	@PostMapping("/sign-up")
+	public ResponseEntity<UserSignUpRes> signUp(
+		@Validated @RequestBody UserSignUpReq userSignUpReq) {
+
+		Long userId = userService.create(
+			userSignUpReq.email(),
+			userSignUpReq.password(),
+			userSignUpReq.name(),
+			userSignUpReq.role());
+
+		return ResponseEntity
+			.created(URI.create("/users/sign-in"))
+			.body(new UserSignUpRes(userId));
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/dto/UserSignUpReq.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/dto/UserSignUpReq.java
@@ -1,0 +1,22 @@
+package prgrms.marco.be02marbox.domain.user.dto;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.Length;
+
+import prgrms.marco.be02marbox.domain.user.Role;
+
+public record UserSignUpReq(
+	@NotEmpty(message = "이메일은 필수 입니다.")
+	@Email(message = "이메일 형식이 틀렸습니다.")
+	String email,
+	@Length(min = 4, max = 8, message = "비밀번호는 4글자 이상, 8글자 이하 입니다.")
+	String password,
+	@NotEmpty(message = "이름은 필수 입니다.")
+	String name,
+	@NotNull(message = "역할은 필수 입니다.")
+	Role role
+) {
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/dto/UserSignUpRes.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/dto/UserSignUpRes.java
@@ -1,0 +1,4 @@
+package prgrms.marco.be02marbox.domain.user.dto;
+
+public record UserSignUpRes(Long id) {
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/exception/DuplicateEmailException.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/exception/DuplicateEmailException.java
@@ -1,0 +1,15 @@
+package prgrms.marco.be02marbox.domain.user.exception;
+
+public class DuplicateEmailException extends UserException {
+
+	private final Message message;
+
+	public DuplicateEmailException(Message message) {
+		this.message = message;
+	}
+
+	@Override
+	public String getMessage() {
+		return message.getMessage();
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/exception/DuplicateNameException.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/exception/DuplicateNameException.java
@@ -1,0 +1,15 @@
+package prgrms.marco.be02marbox.domain.user.exception;
+
+public class DuplicateNameException extends UserException {
+
+	private final Message message;
+
+	public DuplicateNameException(Message message) {
+		this.message = message;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.message.getMessage();
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/exception/Message.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/exception/Message.java
@@ -1,0 +1,16 @@
+package prgrms.marco.be02marbox.domain.user.exception;
+
+public enum Message {
+	DUPLICATE_EMAIL_EXP_MSG("이미 존재하는 이메일 입니다."),
+	DUPLICATE_NAME_EXP_MSG("이미 존재하는 이름입니다.");
+
+	private final String message;
+
+	Message(String message) {
+		this.message = message;
+	}
+
+	public String getMessage() {
+		return this.message;
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/exception/UserException.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/exception/UserException.java
@@ -1,0 +1,4 @@
+package prgrms.marco.be02marbox.domain.user.exception;
+
+public abstract class UserException extends RuntimeException {
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/exhandler/ExceptionController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/exhandler/ExceptionController.java
@@ -1,0 +1,48 @@
+package prgrms.marco.be02marbox.domain.user.exhandler;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import prgrms.marco.be02marbox.domain.user.exception.UserException;
+
+@RestControllerAdvice
+public class ExceptionController {
+
+	public static final String MESSAGE = "message";
+
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<Map<String, List<String>>> handleClientException(MethodArgumentNotValidException exception) {
+		log.error("ClientException : {0}", exception);
+
+		BindingResult bindingResult = exception.getBindingResult();
+		List<String> errors = bindingResult.getAllErrors()
+			.stream()
+			.map(DefaultMessageSourceResolvable::getDefaultMessage)
+			.toList();
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(Map.of(MESSAGE, errors));
+	}
+
+	@ExceptionHandler(UserException.class)
+	public ResponseEntity<Map<String, String>> handleUserException(UserException exception) {
+		log.error("UserException : {0}", exception);
+
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(Map.of(MESSAGE, exception.getMessage()));
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/repository/UserRepository.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/repository/UserRepository.java
@@ -1,8 +1,14 @@
 package prgrms.marco.be02marbox.domain.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import prgrms.marco.be02marbox.domain.user.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
+
+	Optional<User> findByName(String name);
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/user/service/UserService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/user/service/UserService.java
@@ -1,0 +1,40 @@
+package prgrms.marco.be02marbox.domain.user.service;
+
+import static prgrms.marco.be02marbox.domain.user.exception.Message.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import prgrms.marco.be02marbox.domain.user.Role;
+import prgrms.marco.be02marbox.domain.user.User;
+import prgrms.marco.be02marbox.domain.user.exception.DuplicateEmailException;
+import prgrms.marco.be02marbox.domain.user.exception.DuplicateNameException;
+import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	@Transactional
+	public Long create(String email, String password, String name, Role role) {
+		userRepository.findByEmail(email)
+			.ifPresent(user -> {
+				throw new DuplicateEmailException(DUPLICATE_EMAIL_EXP_MSG);
+			});
+
+		userRepository.findByName(name)
+			.ifPresent(user -> {
+				throw new DuplicateNameException(DUPLICATE_NAME_EXP_MSG);
+			});
+
+		User user = new User(email, password, name, role);
+		User savedUser = userRepository.save(user);
+		return savedUser.getId();
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/user/UserIntegrationTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/user/UserIntegrationTest.java
@@ -1,0 +1,64 @@
+package prgrms.marco.be02marbox.domain.user;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import prgrms.marco.be02marbox.domain.user.dto.UserSignUpReq;
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@AutoConfigureTestDatabase
+@AutoConfigureMockMvc
+@Transactional
+class UserIntegrationTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("사용자 회원 가입 API 성공")
+	void testSingUpApiSuccess() throws Exception {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"pang@mail.com",
+			"1234",
+			"pang",
+			Role.ROLE_ADMIN);
+
+		//when then
+		mockMvc.perform(post("/users/sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(userSignUpReq))
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isCreated())
+			.andDo(document("user-sign-up",
+				requestFields(
+					fieldWithPath("email").type(JsonFieldType.STRING).description("사용자 이메일"),
+					fieldWithPath("password").type(JsonFieldType.STRING).description("사용자 비밀번호"),
+					fieldWithPath("name").type(JsonFieldType.STRING).description("사용자 이름"),
+					fieldWithPath("role").type(JsonFieldType.STRING).description("사용자 역할")
+				),
+				responseFields(
+					fieldWithPath("id").type(JsonFieldType.NUMBER).description("사용자 식별 번호")
+				)));
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,137 @@
+package prgrms.marco.be02marbox.domain.user.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static prgrms.marco.be02marbox.domain.user.exception.Message.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import prgrms.marco.be02marbox.domain.user.Role;
+import prgrms.marco.be02marbox.domain.user.dto.UserSignUpReq;
+import prgrms.marco.be02marbox.domain.user.exception.DuplicateEmailException;
+import prgrms.marco.be02marbox.domain.user.exception.DuplicateNameException;
+import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
+import prgrms.marco.be02marbox.domain.user.service.UserService;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+	@MockBean
+	private UserService userService;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("회원 가입 실패 - Role 바인딩 실패해 UserSignUpReq role 필드에 null이 들어감")
+	void testRoleBindingFail() throws Exception {
+		//given
+		StringBuilder req = new StringBuilder();
+		req.append("{\n")
+			.append("\t\"email\" : \"pang@mail.com\",\n")
+			.append("\t\"password\" : \"1234\",\n")
+			.append("\t\"name\" : \"pang\",\n")
+			.append("\t\"Role\" : \"Role\"\n")
+			.append("}");
+
+		//when then
+		mockMvc.perform(post("/users/sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(req.toString())
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().is4xxClientError())
+			.andExpect(jsonPath("$.message.[0]").value(equalTo("역할은 필수 입니다.")));
+	}
+
+	@Test
+	@DisplayName("회원 가입 실패 - 존재하는 이메일")
+	void testSignUpFailBecauseDuplicateEmail() throws Exception {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"pang@mail.com",
+			"1234",
+			"pang",
+			Role.ROLE_ADMIN);
+
+		given(userService.create(
+			userSignUpReq.email(),
+			userSignUpReq.password(),
+			userSignUpReq.name(),
+			userSignUpReq.role()))
+			.willThrow(new DuplicateEmailException(DUPLICATE_EMAIL_EXP_MSG));
+
+		//when then
+		mockMvc.perform(post("/users/sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(userSignUpReq))
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().is4xxClientError())
+			.andExpect(jsonPath("$.message").value(DUPLICATE_EMAIL_EXP_MSG.getMessage()));
+	}
+
+	@Test
+	@DisplayName("회원 가입 실패 - 존재하는 이름")
+	void testSignUpFailBecauseDuplicateName() throws Exception {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"pang@mail.com",
+			"1234",
+			"pang",
+			Role.ROLE_ADMIN);
+
+		given(userService.create(
+			userSignUpReq.email(),
+			userSignUpReq.password(),
+			userSignUpReq.name(),
+			userSignUpReq.role()))
+			.willThrow(new DuplicateNameException(DUPLICATE_NAME_EXP_MSG));
+
+		//when then
+		mockMvc.perform(post("/users/sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(userSignUpReq))
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().is4xxClientError())
+			.andExpect(jsonPath("$.message").value(DUPLICATE_NAME_EXP_MSG.getMessage()));
+	}
+
+	@Test
+	@DisplayName("회원가입 요청 성공")
+	void testSignUpSuccess() throws Exception {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"pang@mail.com",
+			"1234",
+			"pang",
+			Role.ROLE_ADMIN);
+
+		long userId = 1L;
+		given(userService.create(
+			userSignUpReq.email(),
+			userSignUpReq.password(),
+			userSignUpReq.name(),
+			userSignUpReq.role())).willReturn(userId);
+
+		//when then
+		mockMvc.perform(post("/users/sign-up")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(userSignUpReq)))
+			.andExpect(status().isCreated())
+			.andExpect(header().string("location", "/users/sign-in"))
+			.andExpect(jsonPath("$.id").value(userId));
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/user/dto/UserSignUpReqTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/user/dto/UserSignUpReqTest.java
@@ -1,0 +1,108 @@
+package prgrms.marco.be02marbox.domain.user.dto;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import prgrms.marco.be02marbox.domain.user.Role;
+
+class UserSignUpReqTest {
+
+	private static ValidatorFactory factory;
+	private static Validator validator;
+
+	@BeforeAll
+	static void setUp() {
+		factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+
+	@AfterAll
+	static void close() {
+		factory.close();
+	}
+
+	@Test
+	@DisplayName("빈 이메일 전송시 예외 발생")
+	void testEmptyEmail() {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"",
+			"1234",
+			"pang",
+			Role.ROLE_CUSTOMER);
+
+		//when
+		Set<ConstraintViolation<UserSignUpReq>> violations = validator.validate(userSignUpReq);
+
+		//then
+		assertThat(violations).isNotEmpty();
+		violations.forEach(error -> assertThat(error.getMessage()).isEqualTo("이메일은 필수 입니다."));
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 이메일 형식")
+	void testInvalidFormatEmail() {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"aaaaa",
+			"1234",
+			"pang",
+			Role.ROLE_CUSTOMER);
+
+		//when
+		Set<ConstraintViolation<UserSignUpReq>> violations = validator.validate(userSignUpReq);
+
+		//then
+		assertThat(violations).isNotEmpty();
+		violations.forEach(error -> assertThat(error.getMessage()).isEqualTo("이메일 형식이 틀렸습니다."));
+	}
+
+	@ParameterizedTest(name = "틀린 비밀번호 형식 - {0}")
+	@ValueSource(strings = {"", "123", "123456789"})
+	void testInvalidFormatPassword(String password) {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"pang@email.com",
+			password,
+			"pang",
+			Role.ROLE_CUSTOMER);
+
+		//when
+		Set<ConstraintViolation<UserSignUpReq>> violations = validator.validate(userSignUpReq);
+
+		//then
+		assertThat(violations).isNotEmpty();
+		violations.forEach(error -> assertThat(error.getMessage()).isEqualTo("비밀번호는 4글자 이상, 8글자 이하 입니다."));
+	}
+
+	@Test
+	@DisplayName("빈 이메일 전송시 예외 발생")
+	void testEmptyName() {
+		//given
+		UserSignUpReq userSignUpReq = new UserSignUpReq(
+			"pang@email.com",
+			"1234",
+			"",
+			Role.ROLE_CUSTOMER);
+
+		//when
+		Set<ConstraintViolation<UserSignUpReq>> violations = validator.validate(userSignUpReq);
+
+		//then
+		assertThat(violations).isNotEmpty();
+		violations.forEach(error -> assertThat(error.getMessage()).isEqualTo("이름은 필수 입니다."));
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/user/service/UserServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/user/service/UserServiceTest.java
@@ -1,0 +1,99 @@
+package prgrms.marco.be02marbox.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import prgrms.marco.be02marbox.domain.user.Role;
+import prgrms.marco.be02marbox.domain.user.User;
+import prgrms.marco.be02marbox.domain.user.exception.DuplicateEmailException;
+import prgrms.marco.be02marbox.domain.user.exception.DuplicateNameException;
+import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
+
+@DataJpaTest
+class UserServiceTest {
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("사용자 생성 성공")
+	void testSaveSuccess() {
+		//given when
+		Long pangId = userService.create(
+			"pang@mail.com",
+			"1234",
+			"pang",
+			Role.ROLE_CUSTOMER);
+
+		//then
+		Optional<User> user = userRepository.findById(pangId);
+		assertAll(
+			() -> assertThat(user).isNotEmpty(),
+			() -> assertThat(user.get().getId()).isEqualTo(pangId)
+		);
+	}
+
+	@Test
+	@DisplayName("사용 생성 실패 - 이메일 중복")
+	void testSaveFailBecauseDuplicateEmail() {
+		//given
+		String duplicateEmail = "pang@mail.com";
+		User user = new User(
+			duplicateEmail,
+			"1234",
+			"pang",
+			Role.ROLE_CUSTOMER);
+		userRepository.save(user);
+
+		//when then
+		assertThatThrownBy(() -> userService.create(
+			duplicateEmail,
+			"1234",
+			"bang",
+			Role.ROLE_CUSTOMER))
+			.isInstanceOf(DuplicateEmailException.class)
+			.hasMessageContaining("이미 존재하는 이메일 입니다.");
+	}
+
+	@Test
+	@DisplayName("사용 생성 실패 - 이름 중복")
+	void testSaveFailBecauseDuplicateName() {
+		//given
+		String duplicateName = "pang";
+		User user = new User(
+			"pang@mail.com",
+			"1234",
+			duplicateName,
+			Role.ROLE_CUSTOMER);
+		userRepository.save(user);
+
+		//when then
+		assertThatThrownBy(() -> userService.create(
+			"bang@mail.com",
+			"1234",
+			duplicateName,
+			Role.ROLE_CUSTOMER))
+			.isInstanceOf(DuplicateNameException.class)
+			.hasMessageContaining("이미 존재하는 이름입니다.");
+	}
+
+	@TestConfiguration
+	static class Config {
+		@Bean
+		public UserService userService(UserRepository userRepository) {
+			return new UserService(userRepository);
+		}
+	}
+}


### PR DESCRIPTION
## 개요
- 사용자 회원가입 기능 개발

## 추가기능
- 사용자는 회원가입할 수 있다.

## 변경사항(Optional)
- 커밋 메시지 바디에 자세히 명시했습니다.

## 사용방법(Optional)
- 사용자는 이메일, 비밀번호, 이름, 역할 정보를 서버에 넘겨 회원가입한다.
- 이메일, 비밀번호, 이름, 역할은 필수 값이다.
- 이메일, 이름은 중복 불가능하다.
- 비밀번호는 4글자 이상 8글자 이하다.

## 기타
- 시큐리티 설정 파일이 추가됐습니다.
- fix #9 
- 작업하면서 고민됐던 부분은 Comment로 남기겠습니다.
