### PR TITLE
[#46] 예외 Api 용도 Dto 네이밍 변경하기

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/dto/ResponseApiError.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/dto/ResponseApiError.java
@@ -2,7 +2,7 @@ package prgrms.marco.be02marbox.domain.exception.dto;
 
 import java.util.List;
 
-public record ResponseException(
+public record ResponseApiError(
 	List<String> messages,
 	int statusCode
 ) {


### PR DESCRIPTION
## 개요
- 예외 Api 용도 Dto 네이밍 변경하기

## 변경사항(Optional)
- ResponseException 에서 ResponseApiError로 네이밍 변경