### PR TITLE
[#45] 스케줄 클래스 수정 

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/Schedule.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/Schedule.java
@@ -40,7 +40,7 @@ public class Schedule {
 	protected Schedule() {
 	}
 
-	public Schedule(Builder builder) {
+	private Schedule(Builder builder) {
 		this.id = builder.id;
 		this.theaterRoom = builder.theaterRoom;
 		this.movie = builder.movie;
@@ -73,7 +73,6 @@ public class Schedule {
 	}
 
 	public static class Builder {
-
 		private Long id;
 		private TheaterRoom theaterRoom;
 		public Movie movie;

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/ScheduleService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/ScheduleService.java
@@ -38,7 +38,7 @@ public class ScheduleService {
 		Movie movie = movieRepository.findById(requestCreateSchedule.movieId())
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 영화 ID"));
 
-		Schedule schedule = converter.convertFromRequestCreateScheduleToschdeule(requestCreateSchedule, theaterRoom,
+		Schedule schedule = converter.convertFromRequestCreateScheduleToSchedule(requestCreateSchedule, theaterRoom,
 			movie);
 
 		Schedule savedSchedule = scheduleRepository.save(schedule);

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/utils/ScheduleConverter.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/utils/ScheduleConverter.java
@@ -10,7 +10,7 @@ import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSchedule;
 @Component
 public class ScheduleConverter {
 
-	public Schedule convertFromRequestCreateScheduleToschdeule(RequestCreateSchedule request, TheaterRoom theaterRoom,
+	public Schedule convertFromRequestCreateScheduleToSchedule(RequestCreateSchedule request, TheaterRoom theaterRoom,
 		Movie movie) {
 		Schedule schedule = Schedule.builder()
 			.theaterRoom(theaterRoom)

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/ScheduleServiceMockTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/ScheduleServiceMockTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import prgrms.marco.be02marbox.domain.movie.Genre;
+import prgrms.marco.be02marbox.domain.movie.LimitAge;
 import prgrms.marco.be02marbox.domain.movie.Movie;
 import prgrms.marco.be02marbox.domain.movie.repository.MovieRepository;
 import prgrms.marco.be02marbox.domain.theater.Region;
@@ -54,7 +56,7 @@ class ScheduleServiceMockTest {
 		TheaterRoom theaterRoom = new TheaterRoom(theater, "A관");
 		given(theaterRoomRepository.findById(anyLong())).willReturn(Optional.of(theaterRoom));
 
-		Movie movie = new Movie(null, null, null, null, null);
+		Movie movie = new Movie("test", LimitAge.CHILD, Genre.ACTION, 180, "/test/location");
 		given(movieRepository.findById(anyLong())).willReturn(Optional.of(movie));
 
 		Schedule schedule = Schedule.builder()
@@ -64,7 +66,7 @@ class ScheduleServiceMockTest {
 			.endTime(requestCreateSchedule.endTime())
 			.build();
 		given(
-			scheduleConverter.convertFromRequestCreateScheduleToschdeule(any(RequestCreateSchedule.class),
+			scheduleConverter.convertFromRequestCreateScheduleToSchedule(any(RequestCreateSchedule.class),
 				any(TheaterRoom.class),
 				any(Movie.class))).willReturn(
 			schedule);

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/ScheduleServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/ScheduleServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,12 +59,6 @@ class ScheduleServiceTest {
 		theaterRoomRepository.save(theaterRoom);
 		movie = new Movie("test", LimitAge.ADULT, Genre.ACTION, 100, "test");
 		movieRepository.save(movie);
-	}
-
-	@AfterEach
-	void clean() {
-		movieRepository.deleteAll();
-		theaterRoomRepository.deleteAll();
 	}
 
 	@Test


### PR DESCRIPTION
## 개요
- 스케줄 클래스 피드백 반영


## 변경사항(Optional)
- ScheduleServiceTest 파일에서 @AfterEach를 이용해 repository를 비워주는 작업을 제거했습니다.
- ScheduleServiceMockTest 파일에서 Movie 인스턴스를 만들 때 생성자 값에 의미있는 값을 전달했습니다.
- Schedule 클래스에서 빌더 패턴을 이용하는데 불필요한 public 생성자를 private으로 바꿨습니다.
-
## 기타
- fix #45 
