### PR TITLE
[#37] 관리자는 영화관을 조회할 수 있다.

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/Region.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/Region.java
@@ -1,5 +1,16 @@
 package prgrms.marco.be02marbox.domain.theater;
 
 public enum Region {
-	SEOUL, BUSAN;
+	SEOUL,
+	INCHEON,
+	BUSAN,
+	ULSAN,
+	DAEGU,
+	DAEJEON,
+	GWANGJU,
+	GYEONGGI,
+	CHUNGCHEONG,
+	GANGWON,
+	GYEONGSANG,
+	JEOLLA
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/RequestCreateTheater.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/RequestCreateTheater.java
@@ -5,19 +5,4 @@ import javax.validation.constraints.NotBlank;
 public record RequestCreateTheater(
 	@NotBlank(message = "지역명을 입력해주세요.") String region,
 	@NotBlank(message = "영화관 이름을 입력해주세요.") String name) {
-
-	public RequestCreateTheater(String region, String name) {
-		this.region = region;
-		this.name = name;
-	}
-
-	@Override
-	public String region() {
-		return region;
-	}
-
-	@Override
-	public String name() {
-		return name;
-	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterService.java
@@ -1,14 +1,19 @@
 package prgrms.marco.be02marbox.domain.theater.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import prgrms.marco.be02marbox.domain.theater.Theater;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheater;
+import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindTheater;
 import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
 import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterConverter;
 
 @Service
+@Transactional(readOnly = true)
 public class TheaterService {
 
 	private final TheaterRepository theaterRepository;
@@ -24,5 +29,12 @@ public class TheaterService {
 		Theater newTheater = theaterConverter.convertFromRequestCreateTheaterToTheater(request);
 		Theater savedTheater = theaterRepository.save(newTheater);
 		return savedTheater.getId();
+	}
+
+	public List<ResponseFindTheater> findTheaters() {
+		return theaterRepository.findAll()
+			.stream()
+			.map(theaterConverter::convertFromTheaterToResponseFindTheater)
+			.collect(Collectors.toList());
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterServiceTest.java
@@ -1,7 +1,11 @@
 package prgrms.marco.be02marbox.domain.theater.service;
 
+import static java.util.stream.Collectors.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.IntStream;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -14,6 +18,7 @@ import org.springframework.context.annotation.Import;
 import prgrms.marco.be02marbox.domain.theater.Region;
 import prgrms.marco.be02marbox.domain.theater.Theater;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheater;
+import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindTheater;
 import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
 import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterConverter;
 
@@ -29,7 +34,6 @@ class TheaterServiceTest {
 	@Test
 	@DisplayName("영화관 추가 성공")
 	void testCreateTheaterSuccess() {
-
 		// given
 		RequestCreateTheater request = new RequestCreateTheater("SEOUL", "CGV 강남점");
 		// when
@@ -38,9 +42,40 @@ class TheaterServiceTest {
 			.orElseThrow(EntityNotFoundException::new);
 		// then
 		assertAll(
-			() -> assertThat(findTheater.getId()).isEqualTo(1L),
+			() -> assertThat(findTheater.getId()).isEqualTo(savedTheaterId),
 			() -> assertThat(findTheater.getRegion()).isEqualTo(Region.valueOf("SEOUL")),
 			() -> assertThat(findTheater.getName()).isEqualTo("CGV 강남점")
+		);
+	}
+
+	@Test
+	@DisplayName("영화관 추가 실패 - 잘못된 Region")
+	void testCreateTheaterFailed() {
+		// given
+		String wrongRegion = "NEWYORK";
+		RequestCreateTheater request = new RequestCreateTheater(wrongRegion, "CGV 강남점");
+		// expected
+		assertThatThrownBy(
+			() -> theaterService.createTheater(request)
+		).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	@DisplayName("관리자 영화관 전체 조회 - 페이징 X")
+	void testGetAllTheater() {
+		// given
+		List<Theater> theaters = IntStream.range(0, 20)
+			.mapToObj(i -> new Theater(Region.valueOf("SEOUL"), "theater" + i)).collect(toList());
+		theaterRepository.saveAll(theaters);
+
+		// when
+		List<ResponseFindTheater> findTheaters = theaterService.findTheaters();
+
+		// then
+		assertAll(
+			() -> assertThat(findTheaters.size()).isEqualTo(20),
+			() -> assertThat(findTheaters.get(0).region().toString()).isEqualTo("SEOUL"),
+			() -> assertThat(findTheaters.get(0).theaterName()).isEqualTo("theater0")
 		);
 	}
 }


### PR DESCRIPTION
## 개요
관리자 영화 전체 조회 구현

## 추가기능
관리자는 모든 지역에 있는 영화를 조회할 수 있다.

## 변경사항(Optional)
레코드 Getter, 생성자 삭제
영화관 추가 실패 테스트 코드 추가 

## 사용방법(Optional)
관리자 권한이 있는 사람만 전체 영화관을 조회할 수 있다.

