### PR TITLE
[#54] 관리자에게 상영관 추가 API를 제공한다.

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1,0 +1,12 @@
+:hardbreaks:
+ifndef::snippets[]
+:snippets: ../../../target/generated-snippets
+endif::[]
+
+== 영화 예매
+
+### 상영관 등록
+
+.Request
+include::{snippets}/theater-room-save/http-request.adoc[]
+include::{snippets}/theater-room-save/request-fields.adoc[]

--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/custom/BadRequestTheater.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/custom/BadRequestTheater.java
@@ -1,0 +1,7 @@
+package prgrms.marco.be02marbox.domain.exception.custom;
+
+public class BadRequestTheater extends RuntimeException {
+	public BadRequestTheater(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/CommonExceptionHandler.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/CommonExceptionHandler.java
@@ -1,0 +1,25 @@
+package prgrms.marco.be02marbox.domain.exception.handler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import prgrms.marco.be02marbox.domain.exception.dto.ResponseApiError;
+
+@RestControllerAdvice
+public class CommonExceptionHandler {
+	@ExceptionHandler(EntityNotFoundException.class)
+	public ResponseEntity<ResponseApiError> handlerBadRequestException(Exception exception) {
+		List<String> messages = new ArrayList<>();
+
+		messages.add(exception.getMessage());
+		return ResponseEntity.badRequest().body(new ResponseApiError(messages, HttpStatus.BAD_REQUEST.value()));
+	}
+
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/CommonExceptionHandler.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/CommonExceptionHandler.java
@@ -3,8 +3,6 @@ package prgrms.marco.be02marbox.domain.exception.handler;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.persistence.EntityNotFoundException;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,7 +12,7 @@ import prgrms.marco.be02marbox.domain.exception.dto.ResponseApiError;
 
 @RestControllerAdvice
 public class CommonExceptionHandler {
-	@ExceptionHandler(EntityNotFoundException.class)
+	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ResponseApiError> handlerBadRequestException(Exception exception) {
 		List<String> messages = new ArrayList<>();
 

--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/TheaterRoomExceptionHandler.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/TheaterRoomExceptionHandler.java
@@ -8,16 +8,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import prgrms.marco.be02marbox.domain.exception.custom.BadRequestTheater;
 import prgrms.marco.be02marbox.domain.exception.dto.ResponseApiError;
 
 @RestControllerAdvice
-public class CommonExceptionHandler {
-	@ExceptionHandler(IllegalArgumentException.class)
+public class TheaterRoomExceptionHandler {
+	@ExceptionHandler(BadRequestTheater.class)
 	public ResponseEntity<ResponseApiError> handlerBadRequestException(Exception exception) {
 		List<String> messages = new ArrayList<>();
 
 		messages.add(exception.getMessage());
 		return ResponseEntity.badRequest().body(new ResponseApiError(messages, HttpStatus.BAD_REQUEST.value()));
 	}
-
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
@@ -6,6 +6,7 @@ import java.net.URISyntaxException;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,7 +29,7 @@ public class TheaterRoomController {
 
 	@PostMapping
 	public ResponseEntity<Void> save(HttpServletRequest request,
-		@RequestBody RequestCreateTheaterRoom requestCreateTheaterRoom
+		@RequestBody @Validated RequestCreateTheaterRoom requestCreateTheaterRoom
 	) throws URISyntaxException {
 		Long savedId = theaterRoomService.save(requestCreateTheaterRoom);
 		URI redirectUri = new URI(request.getRequestURI() + SLASH + savedId);

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
@@ -1,0 +1,37 @@
+package prgrms.marco.be02marbox.domain.theater.controller;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.service.TheaterRoomService;
+
+@RestController
+@RequestMapping("/theater-rooms")
+public class TheaterRoomController {
+
+	private static final String SLASH = "/";
+
+	private final TheaterRoomService theaterRoomService;
+
+	public TheaterRoomController(TheaterRoomService theaterRoomService) {
+		this.theaterRoomService = theaterRoomService;
+	}
+
+	@PostMapping
+	public ResponseEntity<Void> save(HttpServletRequest request,
+		@RequestBody RequestCreateTheaterRoom requestCreateTheaterRoom
+	) throws URISyntaxException {
+		Long savedId = theaterRoomService.save(requestCreateTheaterRoom);
+		URI redirectUri = new URI(request.getRequestURI() + SLASH + savedId);
+		return ResponseEntity.created(redirectUri).build();
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import prgrms.marco.be02marbox.domain.exception.custom.BadRequestTheater;
 import prgrms.marco.be02marbox.domain.theater.Seat;
 import prgrms.marco.be02marbox.domain.theater.Theater;
 import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
@@ -20,9 +21,10 @@ import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterConverter;
 import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterRoomConverter;
 
 @Service
+@Transactional(readOnly = true)
 public class TheaterRoomService {
 
-	private static final String NOT_FOUND_THEATER_ERR = "극장 정보를 조회할 수 없습니다.";
+	private static final String WRONG_THEATER_ID_ERR_MSG = "바르지 않은 극장 ID 값입니다.";
 
 	private final TheaterRoomRepository theaterRoomRepository;
 	private final TheaterRepository theaterRepository;
@@ -45,7 +47,7 @@ public class TheaterRoomService {
 	@Transactional
 	public Long save(RequestCreateTheaterRoom requestCreateTheaterRoom) {
 		Theater theater = theaterRepository.findById(requestCreateTheaterRoom.theaterId())
-			.orElseThrow(() -> new IllegalArgumentException(NOT_FOUND_THEATER_ERR));
+			.orElseThrow(() -> new BadRequestTheater(WRONG_THEATER_ID_ERR_MSG));
 
 		TheaterRoom newTheaterRoom = new TheaterRoom(theater, requestCreateTheaterRoom.name());
 		TheaterRoom savedTheaterRoom = theaterRoomRepository.save(newTheaterRoom);
@@ -56,7 +58,6 @@ public class TheaterRoomService {
 		return savedTheaterRoom.getId();
 	}
 
-	@Transactional(readOnly = true)
 	public List<ResponseFindTheaterRoom> findAll() {
 		return theaterRoomRepository.findAll().stream()
 			.map(theaterRoom -> {

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
@@ -4,8 +4,6 @@ import static java.util.stream.Collectors.*;
 
 import java.util.List;
 
-import javax.persistence.EntityNotFoundException;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +45,7 @@ public class TheaterRoomService {
 	@Transactional
 	public Long save(RequestCreateTheaterRoom requestCreateTheaterRoom) {
 		Theater theater = theaterRepository.findById(requestCreateTheaterRoom.theaterId())
-			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_THEATER_ERR));
+			.orElseThrow(() -> new IllegalArgumentException(NOT_FOUND_THEATER_ERR));
 
 		TheaterRoom newTheaterRoom = new TheaterRoom(theater, requestCreateTheaterRoom.name());
 		TheaterRoom savedTheaterRoom = theaterRoomRepository.save(newTheaterRoom);

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
@@ -63,7 +63,6 @@ class TheaterRoomControllerTest {
 		)
 			.andExpect(status().isCreated())
 			.andExpect(redirectedUrl(THEATER_ROOM_SAVE_URL + "/" + theaterId))
-			.andDo(print())
 			.andDo(document("theater-room-save",
 				requestFields()
 					.andWithPrefix(SEAT_LIST_PREFIX.getField(), RequestCreateSeatDoc.get())
@@ -79,13 +78,12 @@ class TheaterRoomControllerTest {
 		Long theaterId = 1L;
 		RequestCreateTheaterRoom requestDto = new RequestCreateTheaterRoom(theaterId, "A관", requestCreateSeats);
 
-		given(theaterRoomService.save(requestDto)).willThrow(new EntityNotFoundException("극장 정보를 조회할 수 없습니다."));
+		given(theaterRoomService.save(requestDto)).willThrow(new IllegalArgumentException("극장 정보를 조회할 수 없습니다."));
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(requestDto))
 		)
-			.andDo(print())
 			.andExpect(status().isBadRequest()
 			);
 	}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
@@ -4,34 +4,28 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateTheaterRoomDoc.*;
 
 import java.util.Set;
-
-import javax.persistence.EntityNotFoundException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import prgrms.marco.be02marbox.config.JwtConfigure;
 import prgrms.marco.be02marbox.config.WebSecurityConfigure;
+import prgrms.marco.be02marbox.domain.exception.custom.BadRequestTheater;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSeat;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
 import prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateSeatDoc;
@@ -91,7 +85,7 @@ class TheaterRoomControllerTest {
 		Long theaterId = 1L;
 		RequestCreateTheaterRoom requestDto = new RequestCreateTheaterRoom(theaterId, "A관", requestCreateSeats);
 
-		given(theaterRoomService.save(requestDto)).willThrow(new IllegalArgumentException("극장 정보를 조회할 수 없습니다."));
+		given(theaterRoomService.save(requestDto)).willThrow(new BadRequestTheater("올바르지 않은 극장 ID"));
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
 			.with(SecurityMockMvcRequestPostProcessors.csrf())

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
@@ -1,0 +1,92 @@
+package prgrms.marco.be02marbox.domain.theater.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateTheaterRoomDoc.*;
+
+import java.util.Set;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSeat;
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateSeatDoc;
+import prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateTheaterRoomDoc;
+import prgrms.marco.be02marbox.domain.theater.service.TheaterRoomService;
+
+@WebMvcTest(controllers = TheaterRoomController.class)
+@AutoConfigureRestDocs
+class TheaterRoomControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private TheaterRoomService theaterRoomService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private Set<RequestCreateSeat> requestCreateSeats = Set.of(
+		new RequestCreateSeat(0, 0),
+		new RequestCreateSeat(0, 1)
+	);
+
+	private static final String THEATER_ROOM_SAVE_URL = "/theater-rooms";
+
+	@Test
+	@DisplayName("관리자는 새로운 상영관을 추가할 수 있다.")
+	@WithMockUser(roles = "ADMIN")
+	void testSave() throws Exception {
+		Long theaterId = 1L;
+		RequestCreateTheaterRoom requestDto = new RequestCreateTheaterRoom(theaterId, "A관", requestCreateSeats);
+		given(theaterRoomService.save(requestDto)).willReturn(theaterId);
+
+		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(requestDto))
+		)
+			.andExpect(status().isCreated())
+			.andExpect(redirectedUrl(THEATER_ROOM_SAVE_URL + "/" + theaterId))
+			.andDo(print())
+			.andDo(document("theater-room-save",
+				requestFields()
+					.andWithPrefix(SEAT_LIST_PREFIX.getField(), RequestCreateSeatDoc.get())
+					.and(RequestCreateTheaterRoomDoc.get())
+				)
+			);
+	}
+
+	@Test
+	@DisplayName("극장 ID의 조회 결과가 없는 경우 400 error를 반환한다.")
+	@WithMockUser(roles = "ADMIN")
+	void testSave_400() throws Exception {
+		Long theaterId = 1L;
+		RequestCreateTheaterRoom requestDto = new RequestCreateTheaterRoom(theaterId, "A관", requestCreateSeats);
+
+		given(theaterRoomService.save(requestDto)).willThrow(new EntityNotFoundException("극장 정보를 조회할 수 없습니다."));
+
+		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(requestDto))
+		)
+			.andDo(print())
+			.andExpect(status().isBadRequest()
+			);
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
@@ -17,20 +17,32 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import prgrms.marco.be02marbox.config.JwtConfigure;
+import prgrms.marco.be02marbox.config.WebSecurityConfigure;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSeat;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
 import prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateSeatDoc;
 import prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateTheaterRoomDoc;
 import prgrms.marco.be02marbox.domain.theater.service.TheaterRoomService;
 
-@WebMvcTest(controllers = TheaterRoomController.class)
+@WebMvcTest(controllers = TheaterRoomController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfigure.class)
+	}
+)
 @AutoConfigureRestDocs
 class TheaterRoomControllerTest {
 	@Autowired
@@ -58,6 +70,7 @@ class TheaterRoomControllerTest {
 		given(theaterRoomService.save(requestDto)).willReturn(theaterId);
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
+			.with(SecurityMockMvcRequestPostProcessors.csrf())
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(requestDto))
 		)
@@ -81,6 +94,7 @@ class TheaterRoomControllerTest {
 		given(theaterRoomService.save(requestDto)).willThrow(new IllegalArgumentException("극장 정보를 조회할 수 없습니다."));
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
+			.with(SecurityMockMvcRequestPostProcessors.csrf())
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(requestDto))
 		)

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/dto/document/RequestCreateSeatDoc.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/dto/document/RequestCreateSeatDoc.java
@@ -1,0 +1,48 @@
+package prgrms.marco.be02marbox.domain.theater.dto.document;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public enum RequestCreateSeatDoc {
+	ROW(NUMBER, "row", "행"),
+	COL(NUMBER, "col", "열");
+
+	private JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	RequestCreateSeatDoc(JsonFieldType type, String field, String description) {
+		this.type = type;
+		this.field = field;
+		this.description = description;
+	}
+
+	public JsonFieldType getType() {
+		return type;
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField()).type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> get() {
+		return List.of(
+			ROW.getFieldDescriptor(),
+			COL.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/dto/document/RequestCreateTheaterRoomDoc.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/dto/document/RequestCreateTheaterRoomDoc.java
@@ -1,0 +1,49 @@
+package prgrms.marco.be02marbox.domain.theater.dto.document;
+
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+
+import java.util.List;
+
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public enum RequestCreateTheaterRoomDoc {
+	THEATER_ID(NUMBER, "theaterId", "영화관 id"),
+	NAME(STRING, "name", "상영관 이름"),
+	SEAT_LIST_PREFIX(ARRAY, "requestCreateSeats[]", "좌석 리스트");
+
+	private JsonFieldType type;
+	private final String field;
+	private final String description;
+
+	RequestCreateTheaterRoomDoc(JsonFieldType type, String field, String description) {
+		this.type = type;
+		this.field = field;
+		this.description = description;
+	}
+
+	public JsonFieldType getType() {
+		return type;
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	private FieldDescriptor getFieldDescriptor() {
+		return fieldWithPath(this.getField()).type(this.getType())
+			.description(this.getDescription());
+	}
+
+	public static List<FieldDescriptor> get() {
+		return List.of(
+			THEATER_ID.getFieldDescriptor(),
+			NAME.getFieldDescriptor()
+		);
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
@@ -110,7 +110,7 @@ class TheaterRoomServiceTest {
 	void testSave_entityNotFoundException() {
 		RequestCreateTheaterRoom requestCreateTheaterRoom = new RequestCreateTheaterRoom(-1L, "A관", requestCreateSeats);
 
-		assertThrows(EntityNotFoundException.class, () -> theaterRoomService.save(requestCreateTheaterRoom));
+		assertThrows(IllegalArgumentException.class, () -> theaterRoomService.save(requestCreateTheaterRoom));
 	}
 
 	@Test

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
-import javax.persistence.EntityNotFoundException;
 import javax.persistence.PersistenceContext;
 
 import org.junit.jupiter.api.AfterEach;
@@ -22,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import prgrms.marco.be02marbox.domain.exception.custom.BadRequestTheater;
 import prgrms.marco.be02marbox.domain.theater.Region;
 import prgrms.marco.be02marbox.domain.theater.Seat;
 import prgrms.marco.be02marbox.domain.theater.Theater;
@@ -53,7 +53,6 @@ class TheaterRoomServiceTest {
 
 	@PersistenceContext
 	EntityManager em;
-
 
 	private Theater theater = new Theater(Region.SEOUL, "강남");
 	private Set<RequestCreateSeat> requestCreateSeats = new HashSet<>();
@@ -110,7 +109,7 @@ class TheaterRoomServiceTest {
 	void testSave_entityNotFoundException() {
 		RequestCreateTheaterRoom requestCreateTheaterRoom = new RequestCreateTheaterRoom(-1L, "A관", requestCreateSeats);
 
-		assertThrows(IllegalArgumentException.class, () -> theaterRoomService.save(requestCreateTheaterRoom));
+		assertThrows(BadRequestTheater.class, () -> theaterRoomService.save(requestCreateTheaterRoom));
 	}
 
 	@Test


### PR DESCRIPTION
## 개요
- 관리자에게 상영관 추가 API 제공

## 추가기능
- 상영관 추가 컨트롤러 추가

## 사용방법(Optional)
- method: `post`
- end-point: `theater-rooms`
- 영화관, 등록 될 좌석을 선택한 후 상영관 추가를 요청한다.

## 기타
![image](https://user-images.githubusercontent.com/26343023/175615027-98a3a8f8-d0db-4470-ad5c-ae1662155a83.png)