### PR TITLE
[#8] 관리자는 영화정보 관리를 위해 영화 목록을 조회할 수 있다

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestController.java
@@ -1,10 +1,13 @@
 package prgrms.marco.be02marbox.domain.movie.controller.api;
 
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import prgrms.marco.be02marbox.domain.movie.dto.ResponseGetMovies;
 import prgrms.marco.be02marbox.domain.movie.service.MovieService;
 
 @RequestMapping("/api/movies")
@@ -17,8 +20,9 @@ public class MovieRestController {
 		this.movieService = movieService;
 	}
 
-	@GetMapping
-	public void getMovies(@RequestParam(name = "page", defaultValue = "0") int page, @RequestParam(name = "size", defaultValue = "10") int size) {
-		movieService.getMovies(page, size);
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<ResponseGetMovies> getMovies(@RequestParam(name = "page", defaultValue = "0") int page,
+		@RequestParam(name = "size", defaultValue = "10") int size) {
+		return ResponseEntity.ok().body(new ResponseGetMovies(movieService.getMovies(page, size)));
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestController.java
@@ -1,9 +1,24 @@
 package prgrms.marco.be02marbox.domain.movie.controller.api;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/movies")
+import prgrms.marco.be02marbox.domain.movie.service.MovieService;
+
+@RequestMapping("/api/movies")
 @RestController
 public class MovieRestController {
+
+	private final MovieService movieService;
+
+	public MovieRestController(MovieService movieService) {
+		this.movieService = movieService;
+	}
+
+	@GetMapping
+	public void getMovies(@RequestParam(name = "page", defaultValue = "0") int page, @RequestParam(name = "size", defaultValue = "10") int size) {
+		movieService.getMovies(page, size);
+	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/dto/ResponseGetMovies.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/dto/ResponseGetMovies.java
@@ -1,0 +1,8 @@
+package prgrms.marco.be02marbox.domain.movie.dto;
+
+import java.util.List;
+
+import prgrms.marco.be02marbox.domain.movie.Movie;
+
+public record ResponseGetMovies(List<Movie> movies) {
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
@@ -1,6 +1,7 @@
 package prgrms.marco.be02marbox.domain.movie.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import prgrms.marco.be02marbox.domain.movie.Movie;
 import prgrms.marco.be02marbox.domain.movie.dto.RequestCreateMovie;
@@ -20,6 +21,7 @@ public class MovieService {
 		this.movieConverter = movieConverter;
 	}
 
+	@Transactional
 	public Long createMovie(RequestCreateMovie requestCreateMovie) {
 		Movie newMovie = movieConverter.convertFromRequestCreateMovieToMovie(requestCreateMovie);
 		Movie savedMovie = movieRepository.save(newMovie);

--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
@@ -33,6 +33,7 @@ public class MovieService {
 		return savedMovie.getId();
 	}
 
+	@Transactional(readOnly = true)
 	public List<Movie> getMovies(int page, int size) {
 		return movieRepository.findAll(PageRequest.of(page, size)).getContent();
 	}

--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
@@ -1,5 +1,10 @@
 package prgrms.marco.be02marbox.domain.movie.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,5 +31,9 @@ public class MovieService {
 		Movie newMovie = movieConverter.convertFromRequestCreateMovieToMovie(requestCreateMovie);
 		Movie savedMovie = movieRepository.save(newMovie);
 		return savedMovie.getId();
+	}
+
+	public List<Movie> getMovies(int page, int size) {
+		return movieRepository.findAll(PageRequest.of(page, size)).getContent();
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
@@ -2,9 +2,7 @@ package prgrms.marco.be02marbox.domain.movie.service;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/test/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestControllerTest.java
@@ -1,0 +1,78 @@
+package prgrms.marco.be02marbox.domain.movie.controller.api;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import prgrms.marco.be02marbox.domain.movie.Genre;
+import prgrms.marco.be02marbox.domain.movie.LimitAge;
+import prgrms.marco.be02marbox.domain.movie.Movie;
+import prgrms.marco.be02marbox.domain.movie.dto.RequestCreateMovie;
+import prgrms.marco.be02marbox.domain.movie.service.MovieService;
+
+@WebMvcTest(MovieRestController.class)
+class MovieRestControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private MovieService movieService;
+
+	static RequestCreateMovie frozen;
+	static RequestCreateMovie notebook;
+	static RequestCreateMovie matrix;
+	static RequestCreateMovie tangled;
+	static RequestCreateMovie tazza;
+	static RequestCreateMovie aboutTime;
+
+	@BeforeAll
+	static void beforeAll() {
+		frozen = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ANIMATION, 102, "frozen.png");
+		notebook = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ROMANCE, 124, "notebook.png");
+		matrix = new RequestCreateMovie("Matrix", LimitAge.CHILD, Genre.ACTION, 136, "matrix.png");
+		tangled = new RequestCreateMovie("tangled", LimitAge.CHILD, Genre.ANIMATION, 148, "tangled.png");
+		tazza = new RequestCreateMovie("tazza", LimitAge.ADULT, Genre.ACTION, 186, "tazza.png");
+		aboutTime = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ROMANCE, 124, "notebook.png");
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		mockMvc = MockMvcBuilders.standaloneSetup(new MovieRestController(movieService))
+			.build();
+	}
+
+	@Test
+	void testGetMovies() throws Exception {
+		MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
+		multiValueMap.add("page", "0");
+		multiValueMap.add("size", "5");
+
+		List<Movie> list = new ArrayList<>();
+		list.add(new Movie("Frozen", LimitAge.CHILD, Genre.ANIMATION, 102, "frozen.png"));
+		given(movieService.getMovies(0, 5)).willReturn(list);
+
+		mockMvc.perform(
+				get("/api/movies").params(multiValueMap)
+					.contentType(MediaType.APPLICATION_JSON)
+					.characterEncoding("UTF-8"))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestControllerTest.java
@@ -8,13 +8,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
@@ -23,7 +23,6 @@ import org.springframework.util.MultiValueMap;
 import prgrms.marco.be02marbox.domain.movie.Genre;
 import prgrms.marco.be02marbox.domain.movie.LimitAge;
 import prgrms.marco.be02marbox.domain.movie.Movie;
-import prgrms.marco.be02marbox.domain.movie.dto.RequestCreateMovie;
 import prgrms.marco.be02marbox.domain.movie.service.MovieService;
 
 @WebMvcTest(MovieRestController.class)
@@ -35,30 +34,14 @@ class MovieRestControllerTest {
 	@MockBean
 	private MovieService movieService;
 
-	static RequestCreateMovie frozen;
-	static RequestCreateMovie notebook;
-	static RequestCreateMovie matrix;
-	static RequestCreateMovie tangled;
-	static RequestCreateMovie tazza;
-	static RequestCreateMovie aboutTime;
-
-	@BeforeAll
-	static void beforeAll() {
-		frozen = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ANIMATION, 102, "frozen.png");
-		notebook = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ROMANCE, 124, "notebook.png");
-		matrix = new RequestCreateMovie("Matrix", LimitAge.CHILD, Genre.ACTION, 136, "matrix.png");
-		tangled = new RequestCreateMovie("tangled", LimitAge.CHILD, Genre.ANIMATION, 148, "tangled.png");
-		tazza = new RequestCreateMovie("tazza", LimitAge.ADULT, Genre.ACTION, 186, "tazza.png");
-		aboutTime = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ROMANCE, 124, "notebook.png");
-	}
-
 	@BeforeEach
 	public void beforeEach() {
 		mockMvc = MockMvcBuilders.standaloneSetup(new MovieRestController(movieService))
 			.build();
 	}
 
-	@Test
+/*	@Test
+	@WithMockUser(roles = "ADMIN")
 	void testGetMovies() throws Exception {
 		MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
 		multiValueMap.add("page", "0");
@@ -74,5 +57,5 @@ class MovieRestControllerTest {
 					.characterEncoding("UTF-8"))
 			.andExpect(status().isOk())
 			.andDo(print());
-	}
+	}*/
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/movie/controller/api/MovieRestControllerTest.java
@@ -9,10 +9,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -20,12 +23,17 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import prgrms.marco.be02marbox.config.WebSecurityConfigure;
 import prgrms.marco.be02marbox.domain.movie.Genre;
 import prgrms.marco.be02marbox.domain.movie.LimitAge;
 import prgrms.marco.be02marbox.domain.movie.Movie;
 import prgrms.marco.be02marbox.domain.movie.service.MovieService;
 
-@WebMvcTest(MovieRestController.class)
+@WebMvcTest(controllers = MovieRestController.class,
+	excludeFilters = {
+		@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfigure.class)
+	}
+)
 class MovieRestControllerTest {
 
 	@Autowired
@@ -40,7 +48,7 @@ class MovieRestControllerTest {
 			.build();
 	}
 
-/*	@Test
+	@Test
 	@WithMockUser(roles = "ADMIN")
 	void testGetMovies() throws Exception {
 		MultiValueMap<String, String> multiValueMap = new LinkedMultiValueMap<>();
@@ -57,5 +65,5 @@ class MovieRestControllerTest {
 					.characterEncoding("UTF-8"))
 			.andExpect(status().isOk())
 			.andDo(print());
-	}*/
+	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/movie/service/MovieServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/movie/service/MovieServiceTest.java
@@ -81,9 +81,9 @@ class MovieServiceTest {
 		List<Movie> movies3 = movieService.getMovies(2, 5);
 
 		assertAll(
-			() -> assertThat(movies1.size()).isEqualTo(5),
-			() -> assertThat(movies2.size()).isEqualTo(1),
-			() -> assertThat(movies3.size()).isEqualTo(0)
+			() -> assertThat(movies1).hasSize(5),
+			() -> assertThat(movies2).hasSize(1),
+			() -> assertThat(movies3).hasSize(0)
 		);
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/movie/service/MovieServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/movie/service/MovieServiceTest.java
@@ -3,13 +3,18 @@ package prgrms.marco.be02marbox.domain.movie.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 
 import prgrms.marco.be02marbox.domain.movie.Genre;
 import prgrms.marco.be02marbox.domain.movie.LimitAge;
@@ -28,11 +33,27 @@ class MovieServiceTest {
 	@Autowired
 	MovieRepository movieRepository;
 
+	static RequestCreateMovie frozen;
+	static RequestCreateMovie notebook;
+	static RequestCreateMovie matrix;
+	static RequestCreateMovie tangled;
+	static RequestCreateMovie tazza;
+	static RequestCreateMovie aboutTime;
+
+
+	@BeforeAll
+	static void beforeAll() {
+		frozen = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ANIMATION, 102, "frozen.png");
+		notebook = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ROMANCE, 124, "notebook.png");
+		matrix = new RequestCreateMovie("Matrix", LimitAge.CHILD, Genre.ACTION, 136, "matrix.png");
+		tangled = new RequestCreateMovie("tangled", LimitAge.CHILD, Genre.ANIMATION, 148, "tangled.png");
+		tazza = new RequestCreateMovie("tazza", LimitAge.ADULT, Genre.ACTION, 186, "tazza.png");
+		aboutTime = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ROMANCE, 124, "notebook.png");
+	}
+
 	@Test
 	@DisplayName("movie를 추가할 수 있다")
 	void testCreateMovie() {
-		RequestCreateMovie frozen = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ANIMATION, 102,
-			"frozen.png");
 		Long movieId = movieService.createMovie(frozen);
 		Optional<Movie> found = movieRepository.findById(movieId);
 
@@ -42,6 +63,27 @@ class MovieServiceTest {
 			() -> assertThat(found.get().getLimitAge()).isEqualTo(frozen.limitAge()),
 			() -> assertThat(found.get().getGenre()).isEqualTo(frozen.genre()),
 			() -> assertThat(found.get().getRunningTime()).isEqualTo(frozen.runningTime())
+		);
+	}
+
+	@Test
+	@DisplayName("movie 리스트를 조회할 수 있다")
+	void testGetMovies() {
+		movieService.createMovie(frozen);
+		movieService.createMovie(notebook);
+		movieService.createMovie(matrix);
+		movieService.createMovie(tangled);
+		movieService.createMovie(tazza);
+		movieService.createMovie(aboutTime);
+
+		List<Movie> movies1 = movieService.getMovies(0, 5);
+		List<Movie> movies2 = movieService.getMovies(1, 5);
+		List<Movie> movies3 = movieService.getMovies(2, 5);
+
+		assertAll(
+			() -> assertThat(movies1.size()).isEqualTo(5),
+			() -> assertThat(movies2.size()).isEqualTo(1),
+			() -> assertThat(movies3.size()).isEqualTo(0)
 		);
 	}
 }


### PR DESCRIPTION
## 개요
관리자는 영화정보 관리를 위해 영화 목록을 조회할 수 있다

## 추가기능
- 영화 조회 기능 추가

## 기타
컨트롤러 테스트는 로그인 기능 업데이트 후에 작동이 되지 않아 임시로 주석처리 했습니다.
컨트롤러를 제외하고 보셨으면 좋겠습니다.
