### PR TITLE
[#50] Schedule 도메인 컨트롤러 추가

### DIFF
--- a/src/docs/asciidoc/schedule.adoc
+++ b/src/docs/asciidoc/schedule.adoc
@@ -1,0 +1,16 @@
+:hardbreaks:
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+
+== 스케줄
+
+### 스케줄 등록
+
+.Request
+include::{snippets}/schedule-save/http-request.adoc[]
+include::{snippets}/schedule-save/request-fields.adoc[]
+
+.Response
+include::{snippets}/schedule-save/http-response.adoc[]
+include::{snippets}/schedule-save/response-fields.adoc[]

--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/ScheduleExceptionHandler.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/ScheduleExceptionHandler.java
@@ -13,9 +13,9 @@ import prgrms.marco.be02marbox.domain.exception.dto.ResponseApiError;
 public class ScheduleExceptionHandler {
 
 	@ExceptionHandler(IllegalArgumentException.class)
-	public ResponseEntity<ResponseApiError> illegalArgumentHandle(Exception error) {
-		return ResponseEntity.badRequest()
-			.body(new ResponseApiError(List.of(error.getMessage()), HttpStatus.BAD_REQUEST.value()));
+	public ResponseEntity<ResponseApiError> handleIllegalArgument(Exception error) {
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(new ResponseApiError(List.of(error.getMessage()), HttpStatus.NOT_FOUND.value()));
 	}
 
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/ScheduleExceptionHandler.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/exception/handler/ScheduleExceptionHandler.java
@@ -1,0 +1,21 @@
+package prgrms.marco.be02marbox.domain.exception.handler;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import prgrms.marco.be02marbox.domain.exception.dto.ResponseApiError;
+
+@RestControllerAdvice(basePackages = "prgrms.marco.be02marbox.domain.theater.controller")
+public class ScheduleExceptionHandler {
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ResponseApiError> illegalArgumentHandle(Exception error) {
+		return ResponseEntity.badRequest()
+			.body(new ResponseApiError(List.of(error.getMessage()), HttpStatus.BAD_REQUEST.value()));
+	}
+
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleController.java
@@ -3,6 +3,8 @@ package prgrms.marco.be02marbox.domain.theater.controller;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,7 +25,8 @@ public class ScheduleController {
 	}
 
 	@PostMapping
-	public ResponseEntity<Void> createSchedule(@RequestBody RequestCreateSchedule request) throws URISyntaxException {
+	public ResponseEntity<Void> createSchedule(@Valid @RequestBody RequestCreateSchedule request) throws
+		URISyntaxException {
 		Long scheduleId = scheduleService.createSchedule(request);
 		return ResponseEntity.created(new URI("schedules/" + scheduleId)).build();
 	}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleController.java
@@ -1,0 +1,31 @@
+package prgrms.marco.be02marbox.domain.theater.controller;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSchedule;
+import prgrms.marco.be02marbox.domain.theater.service.ScheduleService;
+
+@RestController
+@RequestMapping("/schedules")
+public class ScheduleController {
+
+	private final ScheduleService scheduleService;
+
+	public ScheduleController(ScheduleService scheduleService) {
+		this.scheduleService = scheduleService;
+	}
+
+	@PostMapping
+	public ResponseEntity<Void> createSchedule(@RequestBody RequestCreateSchedule request) throws URISyntaxException {
+		Long scheduleId = scheduleService.createSchedule(request);
+		return ResponseEntity.created(new URI("schedules/" + scheduleId)).build();
+	}
+
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
@@ -1,0 +1,75 @@
+package prgrms.marco.be02marbox.domain.theater.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSchedule;
+import prgrms.marco.be02marbox.domain.theater.service.ScheduleService;
+
+@WebMvcTest(controllers = ScheduleController.class)
+@AutoConfigureRestDocs
+class ScheduleControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private ScheduleService scheduleService;
+
+	@Test
+	@DisplayName("스케줄 생성 테스트")
+	@WithMockUser(roles = "ADMIN")
+	void testCreateSchedule() throws Exception {
+		RequestCreateSchedule requestCreateSchedule = new RequestCreateSchedule(1L, 1L, LocalDateTime.now(),
+			LocalDateTime.now());
+
+		given(scheduleService.createSchedule(requestCreateSchedule)).willReturn(1L);
+
+		mockMvc.perform(post("/schedules")
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestCreateSchedule)))
+			.andExpect(status().isCreated())
+			.andExpect(header().string("location", "schedules/1"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("상영관 ID가 존재하지 않는 경우 예외 발생")
+	@WithMockUser(roles = "ADMIN")
+	void testCreateScheduleFail() throws Exception {
+		RequestCreateSchedule requestCreateSchedule = new RequestCreateSchedule(100L, 1L, LocalDateTime.now(),
+			LocalDateTime.now());
+
+		given(scheduleService.createSchedule(requestCreateSchedule)).willThrow(
+			new IllegalArgumentException("존재하지 않는 상영관 ID"));
+
+		mockMvc.perform(post("/schedules")
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestCreateSchedule)))
+			.andExpect(status().isBadRequest())
+			.andDo(print());
+	}
+
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
@@ -1,6 +1,9 @@
 package prgrms.marco.be02marbox.domain.theater.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -15,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -51,7 +55,15 @@ class ScheduleControllerTest {
 				.content(objectMapper.writeValueAsString(requestCreateSchedule)))
 			.andExpect(status().isCreated())
 			.andExpect(header().string("location", "schedules/1"))
-			.andDo(print());
+			.andDo(print())
+			.andDo(document("schedule-save",
+				requestFields(
+					fieldWithPath("theaterRoomId").type(JsonFieldType.NUMBER).description("상영관 ID"),
+					fieldWithPath("movieId").type(JsonFieldType.NUMBER).description("영화 ID"),
+					fieldWithPath("startTime").type(JsonFieldType.STRING).description("영화 시작 날짜와 시간"),
+					fieldWithPath("endTime").type(JsonFieldType.STRING).description("영화 종료 날짜와 시간")
+				)));
+
 	}
 
 	@Test

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
@@ -17,17 +17,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import prgrms.marco.be02marbox.config.WebSecurityConfigure;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSchedule;
 import prgrms.marco.be02marbox.domain.theater.service.ScheduleService;
 
-@WebMvcTest(controllers = ScheduleController.class)
+@WebMvcTest(controllers = ScheduleController.class,
+	excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebSecurityConfigure.class)
+)
 @AutoConfigureRestDocs
 class ScheduleControllerTest {
 
@@ -50,6 +56,7 @@ class ScheduleControllerTest {
 		given(scheduleService.createSchedule(requestCreateSchedule)).willReturn(1L);
 
 		mockMvc.perform(post("/schedules")
+				.with(SecurityMockMvcRequestPostProcessors.csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(requestCreateSchedule)))
@@ -77,6 +84,7 @@ class ScheduleControllerTest {
 			new IllegalArgumentException("존재하지 않는 상영관 ID"));
 
 		mockMvc.perform(post("/schedules")
+				.with(SecurityMockMvcRequestPostProcessors.csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(requestCreateSchedule)))

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
@@ -62,7 +62,6 @@ class ScheduleControllerTest {
 				.content(objectMapper.writeValueAsString(requestCreateSchedule)))
 			.andExpect(status().isCreated())
 			.andExpect(header().string("location", "schedules/1"))
-			.andDo(print())
 			.andDo(document("schedule-save",
 				requestFields(
 					fieldWithPath("theaterRoomId").type(JsonFieldType.NUMBER).description("상영관 ID"),
@@ -88,8 +87,7 @@ class ScheduleControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(requestCreateSchedule)))
-			.andExpect(status().isNotFound())
-			.andDo(print());
+			.andExpect(status().isNotFound());
 	}
 
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
@@ -88,7 +88,7 @@ class ScheduleControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(requestCreateSchedule)))
-			.andExpect(status().isBadRequest())
+			.andExpect(status().isNotFound())
 			.andDo(print());
 	}
 


### PR DESCRIPTION
## 개요
- ScheduleController 클래스 추가

## 추가기능
- ScheduleController 클래스 추가
- createSchedule 테스트 추가
- createSchedule asciidoc API 문서 추가

## 기타
fix #50
![image](https://user-images.githubusercontent.com/43159295/175769573-eebd0969-5c65-4155-ba03-e75f03d25529.png)