### PR TITLE
[#83] reserved_seat의 id생성 룰을 정의한다

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/ReservedSeat.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/ReservedSeat.java
@@ -7,6 +7,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 
 import prgrms.marco.be02marbox.domain.theater.Seat;
 
@@ -14,15 +15,45 @@ import prgrms.marco.be02marbox.domain.theater.Seat;
 @Table(name = "reserved_seat")
 public class ReservedSeat {
 
+	private static final String ID_SEPARATOR = "_";
+
 	@Id
-	@Column(name = "id")
+	@Column(name = "id", nullable = false)
 	private String id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "ticket_id")
+	@JoinColumn(name = "ticket_id", nullable = false)
+	@NotNull
 	private Ticket ticket;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "seat_id")
+	@JoinColumn(name = "seat_id", nullable = false)
+	@NotNull
 	private Seat seat;
+
+	protected ReservedSeat() {
+	}
+
+	private void makeReservedSeatId(Long scheduleId, Long seatId) {
+		this.id = scheduleId + ID_SEPARATOR + seatId;
+	}
+
+	public ReservedSeat(Ticket ticket, Seat seat) {
+		makeReservedSeatId(ticket.getSchedule().getId(), seat.getId());
+		this.ticket = ticket;
+		this.seat = seat;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public Ticket getTicket() {
+		return ticket;
+	}
+
+	public Seat getSeat() {
+		return seat;
+	}
+
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/ReservedSeat.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/ReservedSeat.java
@@ -35,7 +35,11 @@ public class ReservedSeat {
 	}
 
 	private void makeReservedSeatId(Long scheduleId, Long seatId) {
-		this.id = scheduleId + ID_SEPARATOR + seatId;
+		this.id = new StringBuilder()
+			.append(scheduleId)
+			.append(ID_SEPARATOR)
+			.append(seatId)
+			.toString();
 	}
 
 	public ReservedSeat(Ticket ticket, Seat seat) {

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/Ticket.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/Ticket.java
@@ -34,4 +34,17 @@ public class Ticket {
 
 	@Column(name = "reserved_at")
 	private LocalDateTime reservedAt;
+
+	public Ticket() {
+	}
+
+	public Ticket(User user, Schedule schedule, LocalDateTime reservedAt) {
+		this.user = user;
+		this.schedule = schedule;
+		this.reservedAt = reservedAt;
+	}
+
+	public Schedule getSchedule() {
+		return schedule;
+	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
@@ -1,0 +1,129 @@
+package prgrms.marco.be02marbox.domain.reservation.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import prgrms.marco.be02marbox.domain.movie.Genre;
+import prgrms.marco.be02marbox.domain.movie.LimitAge;
+import prgrms.marco.be02marbox.domain.movie.Movie;
+import prgrms.marco.be02marbox.domain.movie.repository.MovieRepository;
+import prgrms.marco.be02marbox.domain.reservation.ReservedSeat;
+import prgrms.marco.be02marbox.domain.reservation.Ticket;
+import prgrms.marco.be02marbox.domain.theater.Region;
+import prgrms.marco.be02marbox.domain.theater.Schedule;
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.Theater;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.repository.ScheduleRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.SeatRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRoomRepository;
+import prgrms.marco.be02marbox.domain.user.Role;
+import prgrms.marco.be02marbox.domain.user.User;
+import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
+
+@DataJpaTest
+class ReservedSeatRepositoryTest {
+
+	@Autowired
+	ReservedSeatRepository reservedSeatRepository;
+
+	@Autowired
+	TicketRepository ticketRepository;
+
+	@Autowired
+	SeatRepository seatRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	TheaterRepository theaterRepository;
+
+	@Autowired
+	TheaterRoomRepository theaterRoomRepository;
+
+	@Autowired
+	MovieRepository movieRepository;
+
+	@Autowired
+	ScheduleRepository scheduleRepository;
+
+	@PersistenceContext
+	EntityManager em;
+
+	private Ticket ticket;
+	private Seat seat;
+
+	@BeforeEach
+	void init() {
+		// user
+		User user = new User(
+			"pang@mail.com",
+			"1234",
+			"pang",
+			Role.ROLE_CUSTOMER);
+		userRepository.save(user);
+
+		// theater
+		Theater theater = new Theater(Region.SEOUL, "강남");
+		theaterRepository.save(theater);
+
+		// theaterRoom
+		TheaterRoom theaterRoom = new TheaterRoom(theater, "A관");
+		theaterRoomRepository.save(theaterRoom);
+		em.flush();
+
+		// seat
+		seat = new Seat(theaterRoom, 0, 0);
+		seatRepository.save(seat);
+
+		// movie
+		Movie movie = new Movie("test", LimitAge.ADULT, Genre.ACTION, 100, "test");
+		movieRepository.save(movie);
+
+		// schedule
+		Schedule schedule = Schedule.builder()
+			.theaterRoom(theaterRoom)
+			.movie(movie)
+			.startTime(LocalDateTime.now())
+			.endTime(LocalDateTime.now())
+			.build();
+		scheduleRepository.save(schedule);
+
+		// ticket
+		ticket = new Ticket(user, schedule, LocalDateTime.now());
+		ticketRepository.save(ticket);
+
+		em.flush();
+	}
+
+	@Test
+	@DisplayName("scheduleId와 seatId로 아이디를 생성한다.")
+	void testMakeReservedSeatId() {
+		ReservedSeat reservedSeat = new ReservedSeat(ticket, seat);
+
+		ReservedSeat save = reservedSeatRepository.save(reservedSeat);
+		Optional<ReservedSeat> findReservedSeat = reservedSeatRepository.findById(save.getId());
+
+		assertAll(
+			() -> assertThat(findReservedSeat).isPresent(),
+			() -> {
+				ReservedSeat getReservedSeat = findReservedSeat.get();
+				assertThat(getReservedSeat.getId()).isEqualTo(ticket.getSchedule().getId() + "_" + seat.getId());
+			}
+		);
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
@@ -122,7 +122,11 @@ class ReservedSeatRepositoryTest {
 			() -> assertThat(findReservedSeat).isPresent(),
 			() -> {
 				ReservedSeat getReservedSeat = findReservedSeat.get();
-				assertThat(getReservedSeat.getId()).isEqualTo(ticket.getSchedule().getId() + "_" + seat.getId());
+				StringBuilder makeId = new StringBuilder()
+					.append(ticket.getSchedule().getId())
+					.append("_")
+					.append(seat.getId());
+				assertThat(getReservedSeat.getId()).isEqualTo(makeId.toString());
 			}
 		);
 	}


### PR DESCRIPTION
## 개요
- reserved_seat의 id생성 룰 정의

## 추가기능
- `schedule_id + "_" + seat_id`로 문자열 id를 생성한다

## 기타
- Ticket Entity는 지웅님 담당이셔서 양해를 구하고 테스트를 위한 생성자, getter만 추가하여 반영했습니다.