### PR TITLE
[#98] 스케줄 id에 예약된 좌석 정보를 조회할 수 있다

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepository.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepository.java
@@ -1,8 +1,11 @@
 package prgrms.marco.be02marbox.domain.reservation.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import prgrms.marco.be02marbox.domain.reservation.ReservedSeat;
 
 public interface ReservedSeatRepository extends JpaRepository<ReservedSeat, String> {
+	List<ReservedSeat> searchByIdStartsWith(String scheduleId);
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/Seat.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/Seat.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class Seat {
 
 	@Id
-	@Column(name = "id")
+	@Column(name = "id", nullable = false)
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Long id;
 
@@ -31,10 +31,10 @@ public class Seat {
 	@JoinColumn(name = "theater_room_id")
 	private TheaterRoom theaterRoom;
 
-	@Column(name = "seat_row")
+	@Column(name = "seat_row", nullable = false)
 	private Integer row;
 
-	@Column(name = "seat_col")
+	@Column(name = "seat_col", nullable = false)
 	private Integer column;
 
 	protected Seat() {

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/Seat.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/Seat.java
@@ -21,9 +21,8 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 	@UniqueConstraint(columnNames = {"theater_room_id", "seat_row", "seat_col"})
 })
 public class Seat {
-
 	@Id
-	@Column(name = "id", nullable = false)
+	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Long id;
 

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/TheaterRoom.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/TheaterRoom.java
@@ -25,7 +25,7 @@ import org.hibernate.annotations.Formula;
 @Table(name = "theater_room")
 public class TheaterRoom {
 	@Id
-	@Column(name = "id", nullable = false)
+	@Column(name = "id")
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Long id;
 

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/TheaterRoom.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/TheaterRoom.java
@@ -25,7 +25,7 @@ import org.hibernate.annotations.Formula;
 @Table(name = "theater_room")
 public class TheaterRoom {
 	@Id
-	@Column(name = "id")
+	@Column(name = "id", nullable = false)
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Long id;
 
@@ -34,7 +34,7 @@ public class TheaterRoom {
 	@NotNull
 	private Theater theater;
 
-	@Column(name = "name")
+	@Column(name = "name", nullable = false)
 	@NotNull
 	private String name;
 

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
@@ -1,0 +1,147 @@
+package prgrms.marco.be02marbox.domain.reservation.repository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import prgrms.marco.be02marbox.domain.movie.Genre;
+import prgrms.marco.be02marbox.domain.movie.LimitAge;
+import prgrms.marco.be02marbox.domain.movie.Movie;
+import prgrms.marco.be02marbox.domain.movie.repository.MovieRepository;
+import prgrms.marco.be02marbox.domain.reservation.ReservedSeat;
+import prgrms.marco.be02marbox.domain.reservation.Ticket;
+import prgrms.marco.be02marbox.domain.theater.Region;
+import prgrms.marco.be02marbox.domain.theater.Schedule;
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.Theater;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.repository.ScheduleRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.SeatRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
+import prgrms.marco.be02marbox.domain.theater.repository.TheaterRoomRepository;
+import prgrms.marco.be02marbox.domain.user.Role;
+import prgrms.marco.be02marbox.domain.user.User;
+import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
+
+@DataJpaTest
+class RepositoryTestUtil {
+
+	@PersistenceContext
+	EntityManager em;
+
+	@Autowired
+	ReservedSeatRepository reservedSeatRepository;
+
+	@Autowired
+	TicketRepository ticketRepository;
+
+	@Autowired
+	SeatRepository seatRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	TheaterRepository theaterRepository;
+
+	@Autowired
+	TheaterRoomRepository theaterRoomRepository;
+
+	@Autowired
+	MovieRepository movieRepository;
+
+	@Autowired
+	ScheduleRepository scheduleRepository;
+
+	public Seat saveSeat(TheaterRoom theaterRoom, int row, int col) {
+		Seat seat = new Seat(theaterRoom, row, col);
+		return seatRepository.save(seat);
+	}
+
+	public Seat saveSeat() {
+		TheaterRoom theaterRoom = saveTheaterRoom("A관");
+		Seat seat = new Seat(theaterRoom, 0, 0);
+		return seatRepository.save(seat);
+	}
+
+	public TheaterRoom saveTheaterRoom(String name) {
+		Theater theater = saveTheater("강남");
+		TheaterRoom theaterRoom = new TheaterRoom(theater, name);
+		return theaterRoomRepository.save(theaterRoom);
+	}
+
+	public Theater saveTheater(String name) {
+		Theater theater = new Theater(Region.SEOUL, name);
+		return theaterRepository.save(theater);
+	}
+
+	public User saveUser() {
+		User user = new User(
+			UUID.randomUUID() + "@email.com",
+			"1234",
+			"test",
+			Role.ROLE_CUSTOMER);
+		return userRepository.save(user);
+	}
+
+	public Ticket saveTicket() {
+		User user = saveUser();
+		Schedule schedule = saveSchedule();
+		Ticket ticket = new Ticket(user, schedule, LocalDateTime.now());
+		return ticketRepository.save(ticket);
+	}
+
+	public Schedule saveSchedule() {
+		Movie movie = saveMovie("범죄도시2");
+		TheaterRoom theaterRoom = saveTheaterRoom("A관");
+		Schedule schedule = Schedule.builder()
+			.theaterRoom(theaterRoom)
+			.movie(movie)
+			.startTime(LocalDateTime.now())
+			.endTime(LocalDateTime.now())
+			.build();
+		return scheduleRepository.save(schedule);
+	}
+
+	public Movie saveMovie(String name) {
+		Movie movie = new Movie(name, LimitAge.ADULT, Genre.ACTION, 100, "test");
+		return movieRepository.save(movie);
+	}
+
+	public ReservedSeat saveReservedSeat() {
+		Ticket ticket = saveTicket();
+		Seat seat = saveSeat();
+
+		ReservedSeat reservedSeat = new ReservedSeat(ticket, seat);
+		return reservedSeatRepository.save(reservedSeat);
+	}
+
+	public Schedule saveSameScheduleSeatList(int count) {
+		Ticket ticket = saveTicket();
+		int maxCount = 100;
+		if (count > maxCount) {
+			count = maxCount;
+		}
+		int maxRow = 10;
+		TheaterRoom theaterRoom = saveTheaterRoom("A관");
+		IntStream.range(0, count).forEach((index) -> {
+			int row = index / maxRow;
+			int col = index % maxRow;
+			Seat seat = saveSeat(theaterRoom, row, col);
+			ReservedSeat reservedSeat = new ReservedSeat(ticket, seat);
+			reservedSeatRepository.save(reservedSeat);
+		});
+
+		return ticket.getSchedule();
+	}
+
+	public void queryCall() {
+		em.flush();
+	}
+}


### PR DESCRIPTION
## 개요
- 스케줄 id에 예약된 좌석 정보를 조회할 수 있다

## 추가기능
- schedule_id에 예매된 좌석정보를 조회할 수 있다.

## 변경사항(Optional)
- theater_room, seat에 nullable=false 제약조건 추가 함.
  - 테스트 할 때 null값이 들어가는 경우가 존재 했음

## 사용방법(Optional)
 - `like {schedule_id}_%` 조건으로 예매 된 좌석정보를 조회할 수 있다.