### PR TITLE
[#105] 예매 가능 좌석 정보 조회, 스케줄 id에 예약된 좌석 정보 조회 리펙토링

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/ReservedSeat.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/ReservedSeat.java
@@ -6,19 +6,24 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.PostLoad;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
+
+import org.springframework.data.domain.Persistable;
 
 import prgrms.marco.be02marbox.domain.theater.Seat;
 
 @Entity
 @Table(name = "reserved_seat")
-public class ReservedSeat {
+public class ReservedSeat implements Persistable<String> {
 
 	public static final String ID_SEPARATOR = "_";
 
 	@Id
-	@Column(name = "id", nullable = false)
+	@Column(name = "id")
 	private String id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -30,6 +35,9 @@ public class ReservedSeat {
 	@JoinColumn(name = "seat_id", nullable = false)
 	@NotNull
 	private Seat seat;
+
+	@Transient
+	private boolean isNew = true;
 
 	protected ReservedSeat() {
 	}
@@ -48,8 +56,20 @@ public class ReservedSeat {
 		this.seat = seat;
 	}
 
+	@Override
+	public boolean isNew() {
+		return isNew;
+	}
+
+	@PrePersist
+	@PostLoad
+	void markNotNew() {
+		this.isNew = false;
+	}
+
+	@Override
 	public String getId() {
-		return id;
+		return this.id;
 	}
 
 	public Ticket getTicket() {

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepository.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 import prgrms.marco.be02marbox.domain.reservation.ReservedSeat;
 
 public interface ReservedSeatRepository extends JpaRepository<ReservedSeat, String> {
-
-	@Query("SELECT rs FROM ReservedSeat rs join fetch rs.seat WHERE rs.id LIKE :scheduleId%")
-	List<ReservedSeat> searchByScheduleIdStartsWith(@Param("scheduleId") String scheduleId);
+	@Query("SELECT rs FROM ReservedSeat rs join fetch rs.seat WHERE rs.id LIKE CONCAT(:scheduleId, '\\_', '%')")
+	List<ReservedSeat> searchByScheduleIdStartsWith(@Param("scheduleId") Long scheduleId);
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservedSeatService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservedSeatService.java
@@ -1,7 +1,6 @@
 package prgrms.marco.be02marbox.domain.reservation.service;
 
 import static java.util.stream.Collectors.*;
-import static prgrms.marco.be02marbox.domain.reservation.ReservedSeat.*;
 
 import java.util.List;
 
@@ -31,15 +30,8 @@ public class ReservedSeatService {
 	 * @return 예약 좌석 리스트
 	 */
 	public List<ResponseFindSeat> findByScheduleId(Long scheduleId) {
-		return reservedSeatRepository.searchByScheduleIdStartsWith(makeFindByScheduleParam(scheduleId)).stream()
+		return reservedSeatRepository.searchByScheduleIdStartsWith(scheduleId).stream()
 			.map((reservedSeat -> seatConverter.convertFromSeatToResponseFindSeat(reservedSeat.getSeat())))
 			.collect(toList());
-	}
-
-	private String makeFindByScheduleParam(Long scheduleId) {
-		return new StringBuilder()
-			.append(scheduleId)
-			.append(ID_SEPARATOR)
-			.toString();
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/repository/SeatRepository.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/repository/SeatRepository.java
@@ -3,9 +3,13 @@ package prgrms.marco.be02marbox.domain.theater.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import prgrms.marco.be02marbox.domain.theater.Seat;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 	List<Seat> findByTheaterRoomId(Long theaterRoomId);
+
+	@Query("select s from Seat s where s.theaterRoom.id=:theaterRoomId and s.id not in (:reservedSeatIdList)")
+	List<Seat> findByTheaterRoomIdAndIdNotIn(Long theaterRoomId, List<Long> reservedSeatIdList);
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
@@ -38,8 +38,8 @@ import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
 @DataJpaTest
 public class RepositoryTestUtil {
 
-	private static final int maxRow = 10;
-	private static final int maxCount = (maxRow * maxRow);
+	private static final int MAX_ROW = 10;
+	private static final int MAX_COUNT = (MAX_ROW * MAX_ROW);
 
 	@PersistenceContext
 	public EntityManager em;
@@ -222,15 +222,15 @@ public class RepositoryTestUtil {
 	 */
 
 	private int validateSeatCount(int seatCount) {
-		return Math.min(seatCount, maxCount);
+		return Math.min(seatCount, MAX_COUNT);
 	}
 
 	private int seqToRow(int seq) {
-		return (seq / maxRow);
+		return (seq / MAX_ROW);
 	}
 
 	private int seqToCol(int seq) {
-		return (seq % maxRow);
+		return (seq % MAX_ROW);
 	}
 
 	public void queryCall() {

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
@@ -1,6 +1,7 @@
 package prgrms.marco.be02marbox.domain.reservation.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
@@ -29,8 +30,16 @@ import prgrms.marco.be02marbox.domain.user.Role;
 import prgrms.marco.be02marbox.domain.user.User;
 import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
 
+/**
+ * Entity 저장을 위한 클래스
+ *
+ * save{Entity} 함수는 1개의 고정된 데이터의 Entity 를 저장 후 반환한다. (unique 컬럼이 존재하면 2번 호출 시 Exception)
+ */
 @DataJpaTest
 public class RepositoryTestUtil {
+
+	private static final int maxRow = 10;
+	private static final int maxCount = (maxRow * maxRow);
 
 	@PersistenceContext
 	public EntityManager em;
@@ -59,10 +68,9 @@ public class RepositoryTestUtil {
 	@Autowired
 	public ScheduleRepository scheduleRepository;
 
-	public Seat saveSeat(TheaterRoom theaterRoom, int row, int col) {
-		Seat seat = new Seat(theaterRoom, row, col);
-		return seatRepository.save(seat);
-	}
+	/**
+	 *  Seat
+	 */
 
 	public Seat saveSeat() {
 		TheaterRoom theaterRoom = saveTheaterRoom("A관");
@@ -70,16 +78,55 @@ public class RepositoryTestUtil {
 		return seatRepository.save(seat);
 	}
 
+	/**
+	 * 상영관, 좌석을 지정하여 데이터를 저장한다.
+	 * @param theaterRoom 상영관
+	 * @param row 등록될 행
+	 * @param col 등록될
+	 * @return Seat 생성된 좌석
+	 */
+	public Seat saveSeat(TheaterRoom theaterRoom, int row, int col) {
+		Seat seat = new Seat(theaterRoom, row, col);
+		return seatRepository.save(seat);
+	}
+
+	/**
+	 * 1개 상영관에 포함하는 여러 좌석을 저장한다.
+	 * @param seatCount 좌석 수
+	 * @return TheaterRoom 생성된 상영관 정보
+	 */
+	public TheaterRoom saveSeatMulti(int seatCount) {
+		seatCount = validateSeatCount(seatCount);
+
+		TheaterRoom theaterRoom = saveTheaterRoom("A관");
+		IntStream.range(0, seatCount).forEach((seq) ->
+			saveSeat(theaterRoom, seqToRow(seq), seqToCol(seq))
+		);
+		return theaterRoom;
+	}
+
+	/**
+	 *  TheaterRoom
+	 */
+
 	public TheaterRoom saveTheaterRoom(String name) {
 		Theater theater = saveTheater("강남");
 		TheaterRoom theaterRoom = new TheaterRoom(theater, name);
 		return theaterRoomRepository.save(theaterRoom);
 	}
 
+	/**
+	 *  Theater
+	 */
+
 	public Theater saveTheater(String name) {
 		Theater theater = new Theater(Region.SEOUL, name);
 		return theaterRepository.save(theater);
 	}
+
+	/**
+	 *  User
+	 */
 
 	public User saveUser() {
 		User user = new User(
@@ -90,12 +137,20 @@ public class RepositoryTestUtil {
 		return userRepository.save(user);
 	}
 
+	/**
+	 *  Ticket
+	 */
+
 	public Ticket saveTicket() {
 		User user = saveUser();
 		Schedule schedule = saveSchedule();
 		Ticket ticket = new Ticket(user, schedule, LocalDateTime.now());
 		return ticketRepository.save(ticket);
 	}
+
+	/**
+	 *  Schedule
+	 */
 
 	public Schedule saveSchedule() {
 		Movie movie = saveMovie("범죄도시2");
@@ -109,10 +164,18 @@ public class RepositoryTestUtil {
 		return scheduleRepository.save(schedule);
 	}
 
+	/**
+	 *  Movie
+	 */
+
 	public Movie saveMovie(String name) {
 		Movie movie = new Movie(name, LimitAge.ADULT, Genre.ACTION, 100);
 		return movieRepository.save(movie);
 	}
+
+	/**
+	 *  ReservedSeat
+	 */
 
 	public ReservedSeat saveReservedSeat() {
 		Ticket ticket = saveTicket();
@@ -122,23 +185,52 @@ public class RepositoryTestUtil {
 		return reservedSeatRepository.save(reservedSeat);
 	}
 
+	/**
+	 * 1개의 티켓에 여러개 좌석을 예매하는 데이터를 저장한다.
+	 * @param seatCount 좌석 수
+	 * @return Schedule 티켓의 스케줄 정보
+	 */
 	public Schedule saveReservedSeatMultiSeat(int seatCount) {
+		seatCount = validateSeatCount(seatCount);
+
 		Ticket ticket = saveTicket();
-		int maxCount = 100;
-		if (seatCount > maxCount) {
-			seatCount = maxCount;
-		}
-		int maxRow = 10;
-		TheaterRoom theaterRoom = saveTheaterRoom("A관");
-		IntStream.range(0, seatCount).forEach((index) -> {
-			int row = index / maxRow;
-			int col = index % maxRow;
-			Seat seat = saveSeat(theaterRoom, row, col);
+		IntStream.range(0, seatCount).forEach((seq) -> {
+			Seat seat = saveSeat(ticket.getSchedule().getTheaterRoom(), seqToRow(seq), seqToCol(seq));
+			ReservedSeat reservedSeat = new ReservedSeat(ticket, seat);
+			reservedSeatRepository.save(reservedSeat);
+
+		});
+		return ticket.getSchedule();
+	}
+
+	/**
+	 * 지정한 좌석 리스트를 1개의 티켓에 저장한다.
+	 * @param reserveSeatList 예매 할 좌석 리스트
+	 * @return Schedule 티켓의 스케줄 정보
+	 */
+	public Schedule saveReservedSeatMultiSeat(List<Seat> reserveSeatList) {
+		Ticket ticket = saveTicket();
+		reserveSeatList.forEach((seat) -> {
 			ReservedSeat reservedSeat = new ReservedSeat(ticket, seat);
 			reservedSeatRepository.save(reservedSeat);
 		});
-
 		return ticket.getSchedule();
+	}
+
+	/**
+	 * private 함수
+	 */
+
+	private int validateSeatCount(int seatCount) {
+		return Math.min(seatCount, maxCount);
+	}
+
+	private int seqToRow(int seq) {
+		return (seq / maxRow);
+	}
+
+	private int seqToCol(int seq) {
+		return (seq % maxRow);
 	}
 
 	public void queryCall() {

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
@@ -47,42 +47,16 @@ class ReservedSeatRepositoryTest extends RepositoryTestUtil {
 	void testSearchByIdStartsWith(int expectCount) {
 		Schedule schedule = saveReservedSeatMultiSeat(expectCount);
 
-		String paramId = makeFindByScheduleParam(schedule.getId());
-		List<ReservedSeat> reservedSeats = reservedSeatRepository.searchByScheduleIdStartsWith(paramId);
-
+		List<ReservedSeat> reservedSeats = reservedSeatRepository.searchByScheduleIdStartsWith(schedule.getId());
 		assertThat(reservedSeats).hasSize(expectCount);
 	}
 
 	@Test
-	@DisplayName("like 조건 잘못된 id형식으로 조회하는 경우")
-	void testSearchByIdStartsWithBadParam() {
-		Schedule schedule = saveReservedSeatMultiSeat(1);
-		String paramId = new StringBuilder().append(schedule.getId()).append("\\_\\_").toString();
-		String paramId2 = new StringBuilder().append(schedule.getId()).append("*").toString();
-		String paramId3 = new StringBuilder().append(schedule.getId()).append("?").toString();
-
-		List<ReservedSeat> reservedSeats = reservedSeatRepository.searchByScheduleIdStartsWith(paramId);
-		List<ReservedSeat> reservedSeats2 = reservedSeatRepository.searchByScheduleIdStartsWith(paramId2);
-		List<ReservedSeat> reservedSeats3 = reservedSeatRepository.searchByScheduleIdStartsWith(paramId3);
-
-		assertAll(
-			() -> assertThat(reservedSeats).isEmpty(),
-			() -> assertThat(reservedSeats2).isEmpty(),
-			() -> assertThat(reservedSeats3).isEmpty()
-		);
-	}
-
-	@Test
-	@DisplayName("저장되지 않은 {schedule_id})_ 로 조회하는 경우")
+	@DisplayName("저장되지 않은 {schedule_id}) 로 조회하는 경우")
 	void testSearchByIdStartsWithBadParam2() {
-		Schedule schedule = saveReservedSeatMultiSeat(3);
-		String paramId = makeFindByScheduleParam(schedule.getId() + 1);
-		List<ReservedSeat> reservedSeats = reservedSeatRepository.searchByScheduleIdStartsWith(paramId);
+		Schedule schedule = saveReservedSeatMultiSeat(1);
+		List<ReservedSeat> reservedSeats = reservedSeatRepository.searchByScheduleIdStartsWith(schedule.getId() + 1);
 
 		assertThat(reservedSeats).isEmpty();
-	}
-
-	private String makeFindByScheduleParam(Long scheduleId) {
-		return new StringBuilder().append(scheduleId).append(ID_SEPARATOR).toString();
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/repository/SeatRepositoryTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/repository/SeatRepositoryTest.java
@@ -1,0 +1,64 @@
+package prgrms.marco.be02marbox.domain.theater.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import prgrms.marco.be02marbox.domain.reservation.repository.RepositoryTestUtil;
+import prgrms.marco.be02marbox.domain.theater.Schedule;
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+
+class SeatRepositoryTest extends RepositoryTestUtil {
+
+	@Test
+	@DisplayName("findByRoomId 테스트")
+	void testFindByTheaterRoomId() {
+		TheaterRoom theaterRoom = saveTheaterRoom("A관");
+		TheaterRoom theaterRoom2 = saveTheaterRoom("B관");
+		saveSeat(theaterRoom, 0, 0);
+		saveSeat(theaterRoom, 0, 1);
+		saveSeat(theaterRoom2, 0, 0);
+
+		List<Seat> seatList = seatRepository.findByTheaterRoomId(theaterRoom.getId());
+		List<Seat> seatList2 = seatRepository.findByTheaterRoomId(theaterRoom2.getId());
+
+		assertAll(
+			() -> assertThat(seatList).hasSize(2),
+			() -> assertThat(seatList2).hasSize(1)
+		);
+	}
+
+	@Test
+	@DisplayName("예매 가능한 좌석을 조회할 수 있다.")
+	void testFindByTheaterRoomIdAndIdNotIn() {
+		// 5개 좌석 저장
+		TheaterRoom theaterRoom = saveSeatMulti(5);
+		List<Seat> savedSeats = seatRepository.findByTheaterRoomId(theaterRoom.getId());
+
+		List<Seat> reservedSeatList = new ArrayList<>();
+		// 그 중 2개 좌석을 예약한다.
+		reservedSeatList.add(savedSeats.get(0));
+		reservedSeatList.add(savedSeats.get(1));
+		Schedule schedule = saveReservedSeatMultiSeat(reservedSeatList);
+
+		List<Long> reservedSeatIdList = new ArrayList<>();
+		reservedSeatRepository.searchByScheduleIdStartsWith(schedule.getId())
+			.forEach(reservedSeat -> reservedSeatIdList.add(reservedSeat.getSeat().getId()));
+
+		List<Seat> reservePossibleSeats = seatRepository.findByTheaterRoomIdAndIdNotIn(theaterRoom.getId(),
+			reservedSeatIdList);
+		assertAll(
+			() -> assertThat(reservePossibleSeats).hasSize(3),
+			() -> assertThat(reservePossibleSeats).doesNotContain(savedSeats.get(0)),
+			() -> assertThat(reservePossibleSeats).doesNotContain(savedSeats.get(1)),
+			() -> assertThat(reservePossibleSeats).contains(savedSeats.get(2))
+		);
+	}
+
+}


### PR DESCRIPTION
## 개요
- 예매 가능 좌석 정보 조회 구현
- 스케줄 id에 예약된 좌석 정보 조회 리펙토링

## 추가기능
- 예매 가능 좌석 정보 조회 구현

## 사용방법(Optional)
- 상영관id(theaterRoomId)와 예약된 좌석 정보를 전달받아 특정 상영관의 예매가능한 좌석정보를 조회할 수 있다.

## 변경사항(Optional)
- 기존 스케줄 id에 예약된 좌석 정보 조회로직 변경
  - 기존에는 service에서 `{schedule_id}_` 형태를 만들어서 전달 -> id만 전달받고, jpql에서 `_`를 붙여서 조회하도록 변경
 
- ReservedSeat에 Persistable 추가
  - id를 객체 생성시점에 직접만들어 주어, Data Jpa로 save할 때, select 후 insert하는 문제가 존재하여 추가 함.
  - [참조](https://ttl-blog.tistory.com/201)

## 기타
- RepositoryTestUtil.java는 테스트 과정에서 Entity 저장을 편하게 하고자 만든 클래스이며 가독성이 떨어지는듯하여 주석을 추가했습니다.