### PR TITLE
[#130] TheaterRoom 리팩터링

### DIFF
--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepository.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.repository.query.Param;
 import prgrms.marco.be02marbox.domain.reservation.ReservedSeat;
 
 public interface ReservedSeatRepository extends JpaRepository<ReservedSeat, String> {
-	@Query("SELECT rs FROM ReservedSeat rs join fetch rs.seat WHERE rs.id LIKE CONCAT(:scheduleId, '\\_', '%')")
+	@Query("SELECT rs FROM ReservedSeat rs JOIN FETCH rs.seat WHERE rs.id LIKE CONCAT(:scheduleId, '\\_', '%')")
 	List<ReservedSeat> searchByScheduleIdStartsWith(@Param("scheduleId") Long scheduleId);
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
-import prgrms.marco.be02marbox.domain.theater.service.TheaterRoomService;
+import prgrms.marco.be02marbox.domain.theater.service.TheaterCommonService;
 
 @RestController
 @RequestMapping("/theater-rooms")
@@ -21,17 +21,17 @@ public class TheaterRoomController {
 
 	private static final String SLASH = "/";
 
-	private final TheaterRoomService theaterRoomService;
+	private final TheaterCommonService theaterCommonService;
 
-	public TheaterRoomController(TheaterRoomService theaterRoomService) {
-		this.theaterRoomService = theaterRoomService;
+	public TheaterRoomController(TheaterCommonService theaterCommonService) {
+		this.theaterCommonService = theaterCommonService;
 	}
 
 	@PostMapping
 	public ResponseEntity<Void> save(HttpServletRequest request,
 		@RequestBody @Validated RequestCreateTheaterRoom requestCreateTheaterRoom
 	) throws URISyntaxException {
-		Long savedId = theaterRoomService.save(requestCreateTheaterRoom);
+		Long savedId = theaterCommonService.saveTheaterRoomWithSeatList(requestCreateTheaterRoom);
 		URI redirectUri = new URI(request.getRequestURI() + SLASH + savedId);
 		return ResponseEntity.created(redirectUri).build();
 	}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomController.java
@@ -32,7 +32,7 @@ public class TheaterRoomController {
 		@RequestBody @Validated RequestCreateTheaterRoom requestCreateTheaterRoom
 	) throws URISyntaxException {
 		Long savedId = theaterCommonService.saveTheaterRoomWithSeatList(requestCreateTheaterRoom);
-		URI redirectUri = new URI(request.getRequestURI() + SLASH + savedId);
-		return ResponseEntity.created(redirectUri).build();
+		String redirectUri = new StringBuilder(request.getRequestURI()).append(SLASH).append(savedId).toString();
+		return ResponseEntity.created(URI.create(redirectUri)).build();
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/ResponseFindTheaterRoom.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/dto/ResponseFindTheaterRoom.java
@@ -1,6 +1,7 @@
 package prgrms.marco.be02marbox.domain.theater.dto;
 
-public record ResponseFindTheaterRoom(ResponseFindTheater theater,
+public record ResponseFindTheaterRoom(
+	ResponseFindTheater theater,
 	String theaterRoomName,
 	Integer totalCount) {
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/repository/TheaterRoomRepository.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/repository/TheaterRoomRepository.java
@@ -1,12 +1,17 @@
 package prgrms.marco.be02marbox.domain.theater.repository;
 
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
 
 public interface TheaterRoomRepository extends JpaRepository<TheaterRoom, Long> {
 
 	Set<TheaterRoom> findAllByTheaterId(Long theaterId);
+
+	@Query("SELECT tr FROM TheaterRoom tr JOIN FETCH tr.theater")
+	List<TheaterRoom> findAll();
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterCommonService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterCommonService.java
@@ -1,0 +1,50 @@
+package prgrms.marco.be02marbox.domain.theater.service;
+
+import static java.util.stream.Collectors.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.Theater;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
+
+@Service
+@Transactional(readOnly = true)
+public class TheaterCommonService {
+
+	private final TheaterService theaterService;
+	private final TheaterRoomService theaterRoomService;
+	private final SeatConverter seatConverter;
+
+	public TheaterCommonService(TheaterService theaterService,
+		TheaterRoomService theaterRoomService,
+		SeatConverter seatConverter) {
+		this.theaterService = theaterService;
+		this.theaterRoomService = theaterRoomService;
+		this.seatConverter = seatConverter;
+	}
+
+	/**
+	 * 새로운 상영관 추가
+	 * @param requestCreateTheaterRoom 극장, 상영관 이름, 좌석 정보
+	 * @return 상영관 id
+	 */
+	@Transactional
+	public Long saveTheaterRoomWithSeatList(RequestCreateTheaterRoom requestCreateTheaterRoom) {
+		Theater theater = theaterService.findById(requestCreateTheaterRoom.theaterId());
+
+		TheaterRoom newTheaterRoom = new TheaterRoom(theater, requestCreateTheaterRoom.name());
+		TheaterRoom savedTheaterRoom = theaterRoomService.save(newTheaterRoom);
+		List<Seat> seatList = requestCreateTheaterRoom.requestCreateSeats().stream().map(requestCreateSeat ->
+			seatConverter.convertFromRequestSeatToSeat(savedTheaterRoom, requestCreateSeat)
+		).collect(toList());
+		savedTheaterRoom.addSeats(seatList);
+		return savedTheaterRoom.getId();
+	}
+
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomService.java
@@ -1,22 +1,16 @@
 package prgrms.marco.be02marbox.domain.theater.service;
 
 import static java.util.stream.Collectors.*;
-import static prgrms.marco.be02marbox.domain.exception.custom.Message.*;
 
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import prgrms.marco.be02marbox.domain.theater.Seat;
-import prgrms.marco.be02marbox.domain.theater.Theater;
 import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
-import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
 import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindTheater;
 import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindTheaterRoom;
-import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
 import prgrms.marco.be02marbox.domain.theater.repository.TheaterRoomRepository;
-import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
 import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterConverter;
 import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterRoomConverter;
 
@@ -25,41 +19,25 @@ import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterRoomConverter
 public class TheaterRoomService {
 
 	private final TheaterRoomRepository theaterRoomRepository;
-	private final TheaterRepository theaterRepository;
-	private final SeatConverter seatConverter;
 	private final TheaterRoomConverter theaterRoomConverter;
 	private final TheaterConverter theaterConverter;
 
 	public TheaterRoomService(TheaterRoomRepository theaterRoomRepository,
-		TheaterRepository theaterRepository,
-		SeatConverter seatConverter,
 		TheaterRoomConverter theaterRoomConverter,
 		TheaterConverter theaterConverter) {
 		this.theaterRoomRepository = theaterRoomRepository;
-		this.theaterRepository = theaterRepository;
-		this.seatConverter = seatConverter;
 		this.theaterRoomConverter = theaterRoomConverter;
 		this.theaterConverter = theaterConverter;
 	}
 
 	/**
 	 * 새로운 상영관 추가
-	 * @param requestCreateTheaterRoom 극장, 상영관 이름, 좌석 정보
+	 * @param theaterRoom 저장 될 상영관
 	 * @return 생성된 id
-	 * @throws IllegalArgumentException 극장 정보가 존재하지 않는 경우
 	 */
 	@Transactional
-	public Long save(RequestCreateTheaterRoom requestCreateTheaterRoom) {
-		Theater theater = theaterRepository.findById(requestCreateTheaterRoom.theaterId())
-			.orElseThrow(() -> new IllegalArgumentException(INVALID_THEATER_EXP_MSG.getMessage()));
-
-		TheaterRoom newTheaterRoom = new TheaterRoom(theater, requestCreateTheaterRoom.name());
-		TheaterRoom savedTheaterRoom = theaterRoomRepository.save(newTheaterRoom);
-		List<Seat> seatList = requestCreateTheaterRoom.requestCreateSeats().stream().map(requestCreateSeat ->
-			seatConverter.convertFromRequestSeatToSeat(savedTheaterRoom, requestCreateSeat)
-		).collect(toList());
-		savedTheaterRoom.addSeats(seatList);
-		return savedTheaterRoom.getId();
+	public TheaterRoom save(TheaterRoom theaterRoom) {
+		return theaterRoomRepository.save(theaterRoom);
 	}
 
 	/**
@@ -71,7 +49,7 @@ public class TheaterRoomService {
 			.map(theaterRoom -> {
 				ResponseFindTheater responseFindTheater = theaterConverter.convertFromTheaterToResponseFindTheater(
 					theaterRoom.getTheater());
-				return theaterRoomConverter.convertFromTheaterRoomToTheaterResponseFindTheaterRoom(responseFindTheater,
+				return theaterRoomConverter.convertFromTheaterRoomToResponseFindTheaterRoom(responseFindTheater,
 					theaterRoom);
 			})
 			.collect(toList());

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/TheaterService.java
@@ -86,4 +86,15 @@ public class TheaterService {
 			.map(theaterConverter::convertFromTheaterToResponseFindTheater)
 			.collect(toList());
 	}
+
+	/**
+	 * 상영관 저장시 연관관계 매핑 될 Entity 조회
+	 * @param id 영화관 ID
+	 * @return 영화관 Entity
+	 * @throws EntityNotFoundException 영화관이 존재하지 않는 경우
+	 */
+	public Theater findById(Long id) {
+		return theaterRepository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_THEATER_ERR));
+	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/utils/TheaterRoomConverter.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/utils/TheaterRoomConverter.java
@@ -8,11 +8,8 @@ import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindTheaterRoom;
 
 @Component
 public class TheaterRoomConverter {
-	public ResponseFindTheaterRoom convertFromTheaterRoomToTheaterResponseFindTheaterRoom(
+	public ResponseFindTheaterRoom convertFromTheaterRoomToResponseFindTheaterRoom(
 		ResponseFindTheater responseFindTheater, TheaterRoom theaterRoom) {
-		return new ResponseFindTheaterRoom(responseFindTheater,
-			theaterRoom.getName(),
-			theaterRoom.getTotalAmount()
-		);
+		return new ResponseFindTheaterRoom(responseFindTheater, theaterRoom.getName(), theaterRoom.getTotalAmount());
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/RepositoryTestUtil.java
@@ -9,8 +9,6 @@ import java.util.stream.IntStream;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
@@ -40,11 +38,6 @@ import prgrms.marco.be02marbox.domain.user.repository.UserRepository;
  */
 @DataJpaTest
 public class RepositoryTestUtil {
-
-	void clear() {
-		em.flush();
-		em.clear();
-	}
 
 	private static final int MAX_ROW = 10;
 	private static final int MAX_COUNT = (MAX_ROW * MAX_ROW);
@@ -292,7 +285,8 @@ public class RepositoryTestUtil {
 		return (seq % MAX_ROW);
 	}
 
-	public void queryCall() {
+	private void clear() {
 		em.flush();
+		em.clear();
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/repository/ReservedSeatRepositoryTest.java
@@ -7,7 +7,6 @@ import static prgrms.marco.be02marbox.domain.reservation.ReservedSeat.*;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -17,11 +16,6 @@ import prgrms.marco.be02marbox.domain.reservation.ReservedSeat;
 import prgrms.marco.be02marbox.domain.theater.Schedule;
 
 class ReservedSeatRepositoryTest extends RepositoryTestUtil {
-	@AfterEach
-	void init() {
-		queryCall();
-	}
-
 	@Test
 	@DisplayName("scheduleId와 seatId로 아이디를 생성한다.")
 	void testMakeReservedSeatId() {

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
@@ -30,7 +30,7 @@ import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSeat;
 import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
 import prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateSeatDoc;
 import prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateTheaterRoomDoc;
-import prgrms.marco.be02marbox.domain.theater.service.TheaterRoomService;
+import prgrms.marco.be02marbox.domain.theater.service.TheaterCommonService;
 
 @WebMvcTest(controllers = TheaterRoomController.class,
 	excludeFilters = {
@@ -43,7 +43,7 @@ class TheaterRoomControllerTest {
 	private MockMvc mockMvc;
 
 	@MockBean
-	private TheaterRoomService theaterRoomService;
+	private TheaterCommonService theaterCommonService;
 
 	@Autowired
 	private ObjectMapper objectMapper;
@@ -61,7 +61,7 @@ class TheaterRoomControllerTest {
 	void testSave() throws Exception {
 		Long theaterId = 1L;
 		RequestCreateTheaterRoom requestDto = new RequestCreateTheaterRoom(theaterId, "A관", requestCreateSeats);
-		given(theaterRoomService.save(requestDto)).willReturn(theaterId);
+		given(theaterCommonService.saveTheaterRoomWithSeatList(requestDto)).willReturn(theaterId);
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
 			.with(SecurityMockMvcRequestPostProcessors.csrf())
@@ -85,7 +85,7 @@ class TheaterRoomControllerTest {
 		Long theaterId = 1L;
 		RequestCreateTheaterRoom requestDto = new RequestCreateTheaterRoom(theaterId, "A관", requestCreateSeats);
 
-		given(theaterRoomService.save(requestDto)).willThrow(
+		given(theaterCommonService.saveTheaterRoomWithSeatList(requestDto)).willThrow(
 			new IllegalArgumentException(INVALID_THEATER_EXP_MSG.getMessage()));
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterCommonServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterCommonServiceTest.java
@@ -1,0 +1,81 @@
+package prgrms.marco.be02marbox.domain.theater.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import prgrms.marco.be02marbox.domain.reservation.repository.RepositoryTestUtil;
+import prgrms.marco.be02marbox.domain.theater.Seat;
+import prgrms.marco.be02marbox.domain.theater.Theater;
+import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSeat;
+import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
+import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
+import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterConverter;
+import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterRoomConverter;
+
+@DataJpaTest
+@Import({TheaterCommonService.class, TheaterService.class, TheaterRoomService.class,
+	SeatConverter.class, TheaterConverter.class, TheaterRoomConverter.class})
+class TheaterCommonServiceTest extends RepositoryTestUtil {
+
+	@Autowired
+	TheaterCommonService theaterCommonService;
+
+	private Set<RequestCreateSeat> requestCreateSeats = Set.of(
+		new RequestCreateSeat(0, 0),
+		new RequestCreateSeat(0, 1)
+	);
+
+	private Theater theater;
+
+	@BeforeEach
+	void init() {
+		theater = saveTheater("강남");
+	}
+
+	@AfterEach
+	void clear() {
+		theaterRepository.deleteById(theater.getId());
+	}
+
+	@Test
+	@DisplayName("새로운 상영관을 추가할 수 있다.")
+	void testSaveTheaterRoomWithSeatList() {
+		Theater theater = saveTheater("강남");
+		RequestCreateTheaterRoom requestCreateTheaterRoom = new RequestCreateTheaterRoom(theater.getId(), "A관",
+			requestCreateSeats);
+		int expectTotalCount = requestCreateSeats.size();
+		Long savedId = theaterCommonService.saveTheaterRoomWithSeatList(requestCreateTheaterRoom);
+
+		Optional<TheaterRoom> findTheaterRoom = theaterRoomRepository.findById(savedId);
+		List<Seat> findSeats = seatRepository.findByTheaterRoomId(savedId);
+		assertAll(
+			() -> assertThat(findTheaterRoom).isPresent(),
+			() -> assertThat(findSeats).hasSize(expectTotalCount)
+		);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 Theater의 요청은 EntityNotFoundException 발생")
+	void testSave_entityNotFoundException() {
+		RequestCreateTheaterRoom requestCreateTheaterRoom =
+			new RequestCreateTheaterRoom(-1L, "A관", requestCreateSeats);
+
+		assertThrows(EntityNotFoundException.class,
+			() -> theaterCommonService.saveTheaterRoomWithSeatList(requestCreateTheaterRoom));
+	}
+}

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/TheaterRoomServiceTest.java
@@ -3,139 +3,35 @@ package prgrms.marco.be02marbox.domain.theater.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import prgrms.marco.be02marbox.domain.theater.Region;
-import prgrms.marco.be02marbox.domain.theater.Seat;
-import prgrms.marco.be02marbox.domain.theater.Theater;
-import prgrms.marco.be02marbox.domain.theater.TheaterRoom;
-import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateSeat;
-import prgrms.marco.be02marbox.domain.theater.dto.RequestCreateTheaterRoom;
+import prgrms.marco.be02marbox.domain.reservation.repository.RepositoryTestUtil;
 import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindTheaterRoom;
-import prgrms.marco.be02marbox.domain.theater.repository.SeatRepository;
-import prgrms.marco.be02marbox.domain.theater.repository.TheaterRepository;
-import prgrms.marco.be02marbox.domain.theater.repository.TheaterRoomRepository;
-import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
 import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterConverter;
 import prgrms.marco.be02marbox.domain.theater.service.utils.TheaterRoomConverter;
 
-@DataJpaTest
-@Import({TheaterRoomService.class, SeatConverter.class, TheaterRoomConverter.class, TheaterConverter.class})
-class TheaterRoomServiceTest {
-
-	Logger log = LoggerFactory.getLogger(this.getClass());
+@Import({TheaterRoomService.class, TheaterRoomConverter.class, TheaterConverter.class})
+class TheaterRoomServiceTest extends RepositoryTestUtil {
 
 	@Autowired
 	TheaterRoomService theaterRoomService;
-	@Autowired
-	TheaterRepository theaterRepository;
-	@Autowired
-	TheaterRoomRepository theaterRoomRepository;
-	@Autowired
-	SeatRepository seatRepository;
-
-	@PersistenceContext
-	EntityManager em;
-
-	private Theater theater = new Theater(Region.SEOUL, "강남");
-	private Set<RequestCreateSeat> requestCreateSeats = new HashSet<>();
-
-	@BeforeEach
-	void init() {
-		requestCreateSeats.add(new RequestCreateSeat(0, 0));
-		theaterRepository.save(theater);
-	}
-
-	@AfterEach
-	void clear() {
-		requestCreateSeats.clear();
-	}
-
-	@Test
-	@DisplayName("새로운 상영관을 추가할 수 있다.")
-	void testSave() {
-		RequestCreateTheaterRoom requestCreateTheaterRoom = new RequestCreateTheaterRoom(theater.getId(), "A관",
-			requestCreateSeats);
-		int expectTotalCount = requestCreateSeats.size();
-		Long savedId = theaterRoomService.save(requestCreateTheaterRoom);
-
-		Optional<TheaterRoom> findTheaterRoom = theaterRoomRepository.findById(savedId);
-		List<Seat> findSeats = seatRepository.findByTheaterRoomId(savedId);
-
-		assertAll(
-			() -> assertThat(findTheaterRoom).isPresent(),
-			() -> assertThat(findSeats).hasSize(expectTotalCount)
-		);
-	}
-
-	@Test
-	@DisplayName("하나의 상영관에는 동일한 row, col을 가진 좌석이 존재할 수 없다.")
-	void testSave_distinct() {
-		requestCreateSeats.add(new RequestCreateSeat(0, 1));
-		requestCreateSeats.add(new RequestCreateSeat(0, 2));
-		requestCreateSeats.add(new RequestCreateSeat(0, 1));
-		requestCreateSeats.add(new RequestCreateSeat(0, 2));
-		requestCreateSeats.add(new RequestCreateSeat(0, 1));
-		requestCreateSeats.add(new RequestCreateSeat(0, 2));
-
-		RequestCreateTheaterRoom requestCreateTheaterRoom = new RequestCreateTheaterRoom(theater.getId(), "A관",
-			requestCreateSeats);
-		int expectTotalCount = 3;
-		Long savedId = theaterRoomService.save(requestCreateTheaterRoom);
-		List<Seat> findSeats = seatRepository.findByTheaterRoomId(savedId);
-
-		assertThat(findSeats).hasSize(expectTotalCount);
-	}
-
-	@Test
-	@DisplayName("존재하지 않는 Theater의 요청은 EntityNotFoundException 발생")
-	void testSave_entityNotFoundException() {
-		RequestCreateTheaterRoom requestCreateTheaterRoom = new RequestCreateTheaterRoom(-1L, "A관", requestCreateSeats);
-
-		assertThrows(IllegalArgumentException.class, () -> theaterRoomService.save(requestCreateTheaterRoom));
-	}
 
 	@Test
 	@DisplayName("전체 상영관 정보 조회")
 	void testFindAll() {
-		RequestCreateTheaterRoom requestCreateTheaterRoom = new RequestCreateTheaterRoom(
-			theater.getId(),
-			"A관",
-			requestCreateSeats
-		);
-
-		RequestCreateTheaterRoom requestCreateTheaterRoom2 = new RequestCreateTheaterRoom(
-			theater.getId(),
-			"B관",
-			requestCreateSeats
-		);
-
-		theaterRoomService.save(requestCreateTheaterRoom);
-		theaterRoomService.save(requestCreateTheaterRoom2);
-		em.flush();
-		em.clear();
+		saveTheaterRoom("A관");
+		saveTheaterRoom("B관");
 
 		List<ResponseFindTheaterRoom> theaterRoomList = theaterRoomService.findAll();
 		assertAll(
 			() -> assertThat(theaterRoomList).hasSize(2),
-			() -> assertThat(theaterRoomList.get(0).totalCount()).isEqualTo(1),
-			() -> assertThat(theaterRoomList.get(1).totalCount()).isEqualTo(1)
+			() -> assertThat(theaterRoomList.get(0).totalCount()).isZero(),
+			() -> assertThat(theaterRoomList.get(1).totalCount()).isZero()
 		);
 	}
 }


### PR DESCRIPTION
## 개요
- TheaterRoom 리팩터링

## 추가기능
- theater 도메인에서 여러 Service를 의존받는 공통 Service 추가 함.
  - `TheaterCommonService.java`

## 변경사항(Optional)
### 변경 전
- findAll에서 Theater Convert수행시 N+1 문제 발생
- TheaterRoomService에서 theaterRepository를 직접 사용함

### 변경 후
- N+1문제 fetch join으로 해결
- Service 의존성을 분리하기 위해 TheaterCommonService 추가 및 기존 save로직 분리
- TheaterService에 findById로 Entity반환하는 메서드 추가