### PR TITLE
[#147] 예매좌석 조회 API 통합

### DIFF
--- a/src/docs/asciidoc/reserved_seat.adoc
+++ b/src/docs/asciidoc/reserved_seat.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 == 예매좌석 조회
 
-### 스케줄 별 예매(되어있는)좌석 조회
+### 스케줄 별 예매 좌석 정보
 
 .Request
 include::{snippets}/reserved-seat/http-request.adoc[]
@@ -13,12 +13,3 @@ include::{snippets}/reserved-seat/http-request.adoc[]
 .Response
 include::{snippets}/reserved-seat/http-response.adoc[]
 include::{snippets}/reserved-seat/response-fields.adoc[]
-
-### 스케줄 별 예매(가능한)좌석 조회
-
-.Request
-include::{snippets}/reserved-seat-possible/http-request.adoc[]
-
-.Response
-include::{snippets}/reserved-seat-possible/http-response.adoc[]
-include::{snippets}/reserved-seat-possible/response-fields.adoc[]

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/controller/ReservedSeatController.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/controller/ReservedSeatController.java
@@ -8,29 +8,21 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import prgrms.marco.be02marbox.domain.reservation.dto.ResponseFindReservedSeat;
 import prgrms.marco.be02marbox.domain.reservation.service.ReservationService;
-import prgrms.marco.be02marbox.domain.reservation.service.ReservedSeatService;
-import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindSeat;
 
 @RestController
 @RequestMapping("/reserved-seat")
 public class ReservedSeatController {
 
-	private final ReservedSeatService reservedSeatService;
 	private final ReservationService reservationService;
 
-	public ReservedSeatController(ReservedSeatService reservedSeatService, ReservationService reservationService) {
-		this.reservedSeatService = reservedSeatService;
+	public ReservedSeatController(ReservationService reservationService) {
 		this.reservationService = reservationService;
 	}
 
 	@GetMapping("/{scheduleId}")
-	public ResponseEntity<List<ResponseFindSeat>> findByScheduleId(@PathVariable Long scheduleId) {
-		return ResponseEntity.ok(reservedSeatService.findByScheduleId(scheduleId));
-	}
-
-	@GetMapping("/{scheduleId}/possible")
-	public ResponseEntity<List<ResponseFindSeat>> findReservePossibleSeats(@PathVariable Long scheduleId) {
+	public ResponseEntity<List<ResponseFindReservedSeat>> findReservePossibleSeats(@PathVariable Long scheduleId) {
 		return ResponseEntity.ok(reservationService.findReservePossibleSeatList(scheduleId));
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/dto/ResponseFindReservedSeat.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/dto/ResponseFindReservedSeat.java
@@ -1,0 +1,4 @@
+package prgrms.marco.be02marbox.domain.reservation.dto;
+
+public record ResponseFindReservedSeat(Integer row, Integer col, Boolean reserved) {
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservationService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservationService.java
@@ -1,12 +1,13 @@
 package prgrms.marco.be02marbox.domain.reservation.service;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import prgrms.marco.be02marbox.domain.reservation.dto.ResponseFindReservedSeat;
 import prgrms.marco.be02marbox.domain.theater.Schedule;
-import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindSeat;
 import prgrms.marco.be02marbox.domain.theater.service.ScheduleService;
 import prgrms.marco.be02marbox.domain.theater.service.SeatService;
 
@@ -29,12 +30,12 @@ public class ReservationService {
 	 * 스케줄 별 예약좌석 조회
 	 *
 	 * @param scheduleId 스케줄 id
-	 * @return 예약(되어있는) 좌석의 id 리스트
+	 * @return 예약 좌석리스트
 	 */
-	public List<ResponseFindSeat> findReservePossibleSeatList(Long scheduleId) {
+	public List<ResponseFindReservedSeat> findReservePossibleSeatList(Long scheduleId) {
 		Schedule schedule = scheduleService.findById(scheduleId);
 
-		List<Long> reservedSeatIdList = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
-		return seatService.findRemainSeats(schedule.getTheaterRoom().getId(), reservedSeatIdList);
+		Set<Long> reservedSeatIdList = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
+		return seatService.findReservedSeat(schedule.getTheaterRoom().getId(), reservedSeatIdList);
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservationService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservationService.java
@@ -36,6 +36,6 @@ public class ReservationService {
 		Schedule schedule = scheduleService.findById(scheduleId);
 
 		Set<Long> reservedSeatIdList = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
-		return seatService.findReservedSeat(schedule.getTheaterRoom().getId(), reservedSeatIdList);
+		return seatService.findAvailableSeatList(schedule.getTheaterRoom().getId(), reservedSeatIdList);
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservedSeatService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/reservation/service/ReservedSeatService.java
@@ -2,37 +2,21 @@ package prgrms.marco.be02marbox.domain.reservation.service;
 
 import static java.util.stream.Collectors.*;
 
-import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import prgrms.marco.be02marbox.domain.reservation.repository.ReservedSeatRepository;
-import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindSeat;
-import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
 
 @Service
 @Transactional(readOnly = true)
 public class ReservedSeatService {
 
 	private final ReservedSeatRepository reservedSeatRepository;
-	private final SeatConverter seatConverter;
 
-	public ReservedSeatService(ReservedSeatRepository reservedSeatRepository, SeatConverter seatConverter) {
+	public ReservedSeatService(ReservedSeatRepository reservedSeatRepository) {
 		this.reservedSeatRepository = reservedSeatRepository;
-		this.seatConverter = seatConverter;
-	}
-
-	/**
-	 * 스케줄 별 예약좌석 조회
-	 *
-	 * @param scheduleId 스케줄 id
-	 * @return 예약(되어있는) 좌석 리스트
-	 */
-	public List<ResponseFindSeat> findByScheduleId(Long scheduleId) {
-		return reservedSeatRepository.searchByScheduleIdStartsWith(scheduleId).stream()
-			.map((reservedSeat -> seatConverter.convertFromSeatToResponseFindSeat(reservedSeat.getSeat())))
-			.collect(toList());
 	}
 
 	/**
@@ -41,9 +25,9 @@ public class ReservedSeatService {
 	 * @param scheduleId 스케줄 id
 	 * @return 예약(되어있는) 좌석의 id 리스트
 	 */
-	public List<Long> findReservedIdListByScheduleId(Long scheduleId) {
+	public Set<Long> findReservedIdListByScheduleId(Long scheduleId) {
 		return reservedSeatRepository.searchByScheduleIdStartsWith(scheduleId).stream()
-			.map((reservedSeat) -> reservedSeat.getSeat().getId())
-			.collect(toList());
+			.map(reservedSeat -> reservedSeat.getSeat().getId())
+			.collect(toSet());
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/SeatService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/SeatService.java
@@ -1,24 +1,22 @@
 package prgrms.marco.be02marbox.domain.theater.service;
 
-import static java.util.stream.Collectors.*;
-
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 
-import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindSeat;
+import prgrms.marco.be02marbox.domain.reservation.dto.ResponseFindReservedSeat;
+import prgrms.marco.be02marbox.domain.theater.Seat;
 import prgrms.marco.be02marbox.domain.theater.repository.SeatRepository;
-import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
 
 @Service
 public class SeatService {
 
 	private final SeatRepository seatRepository;
-	private final SeatConverter seatConverter;
 
-	public SeatService(SeatRepository seatRepository, SeatConverter seatConverter) {
+	public SeatService(SeatRepository seatRepository) {
 		this.seatRepository = seatRepository;
-		this.seatConverter = seatConverter;
 	}
 
 	/**
@@ -26,11 +24,19 @@ public class SeatService {
 	 *
 	 * @param theaterRoomId 상영관 ID
 	 * @param reservedSeatIdList 예약 된 좌석리스트
-	 * @return 예약 가능한 좌석 리스트
+	 * @return 예약 가능 좌석 정보
 	 */
-	public List<ResponseFindSeat> findRemainSeats(Long theaterRoomId, List<Long> reservedSeatIdList) {
-		return seatRepository.findByTheaterRoomIdAndIdNotIn(theaterRoomId, reservedSeatIdList).stream()
-			.map(seatConverter::convertFromSeatToResponseFindSeat)
-			.collect(toList());
+	public List<ResponseFindReservedSeat> findReservedSeat(Long theaterRoomId, Set<Long> reservedSeatIdList) {
+		List<Seat> allSeat = seatRepository.findByTheaterRoomId(theaterRoomId);
+		List<ResponseFindReservedSeat> seatList = new ArrayList<>();
+
+		allSeat.forEach(seat -> {
+			boolean reserved = false;
+			if (reservedSeatIdList.contains(seat.getId())) {
+				reserved = true;
+			}
+			seatList.add(new ResponseFindReservedSeat(seat.getRow(), seat.getColumn(), reserved));
+		});
+		return seatList;
 	}
 }

--- a/src/main/java/prgrms/marco/be02marbox/domain/theater/service/SeatService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/theater/service/SeatService.java
@@ -26,15 +26,12 @@ public class SeatService {
 	 * @param reservedSeatIdList 예약 된 좌석리스트
 	 * @return 예약 가능 좌석 정보
 	 */
-	public List<ResponseFindReservedSeat> findReservedSeat(Long theaterRoomId, Set<Long> reservedSeatIdList) {
+	public List<ResponseFindReservedSeat> findAvailableSeatList(Long theaterRoomId, Set<Long> reservedSeatIdList) {
 		List<Seat> allSeat = seatRepository.findByTheaterRoomId(theaterRoomId);
 		List<ResponseFindReservedSeat> seatList = new ArrayList<>();
 
 		allSeat.forEach(seat -> {
-			boolean reserved = false;
-			if (reservedSeatIdList.contains(seat.getId())) {
-				reserved = true;
-			}
+			boolean reserved = reservedSeatIdList.contains(seat.getId());
 			seatList.add(new ResponseFindReservedSeat(seat.getRow(), seat.getColumn(), reserved));
 		});
 		return seatList;

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/controller/ReservedSeatControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/controller/ReservedSeatControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static prgrms.marco.be02marbox.domain.theater.dto.document.ResponseCreateSeatDoc.*;
+import static prgrms.marco.be02marbox.domain.theater.dto.document.ResponseFindReservedSeatDoc.*;
 
 import java.util.List;
 
@@ -24,10 +25,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import prgrms.marco.be02marbox.config.WebSecurityConfigure;
+import prgrms.marco.be02marbox.domain.reservation.dto.ResponseFindReservedSeat;
 import prgrms.marco.be02marbox.domain.reservation.service.ReservationService;
 import prgrms.marco.be02marbox.domain.reservation.service.ReservedSeatService;
 import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindSeat;
 import prgrms.marco.be02marbox.domain.theater.dto.document.ResponseCreateSeatDoc;
+import prgrms.marco.be02marbox.domain.theater.dto.document.ResponseFindReservedSeatDoc;
 
 @WebMvcTest(controllers = ReservedSeatController.class,
 	excludeFilters = {
@@ -52,17 +55,15 @@ class ReservedSeatControllerTest {
 
 	@Test
 	@WithMockUser(roles = {"USER", "ADMIN"})
-	@DisplayName("선택 된 스케줄에 예약된 좌석 정보 조회")
-	void testFindByScheduleId() throws Exception {
+	@DisplayName("선택 된 스케줄에 예약된 좌석 정보 조회 - id 리스트 반환")
+	void testFindReservedIdListByScheduleId() throws Exception {
 		Long scheduleId = 1L;
 
-		List<ResponseFindSeat> seatList = List.of(
-			new ResponseFindSeat(0, 0),
-			new ResponseFindSeat(0, 1),
-			new ResponseFindSeat(0, 2)
-		);
+		List<ResponseFindReservedSeat> seatList = List.of(
+			new ResponseFindReservedSeat(0, 0, false),
+			new ResponseFindReservedSeat(0, 1, true));
 
-		given(reservedSeatService.findByScheduleId(scheduleId)).willReturn(seatList);
+		given(reservationService.findReservePossibleSeatList(scheduleId)).willReturn(seatList);
 
 		mockMvc.perform(get(RESERVED_SEAT_URL + "/{scheduleId}", scheduleId)
 			.with(SecurityMockMvcRequestPostProcessors.csrf())
@@ -70,29 +71,7 @@ class ReservedSeatControllerTest {
 			.andExpect(status().isOk())
 			.andDo(document("reserved-seat",
 				responseFields()
-					.andWithPrefix(ARRAY_PREFIX.getField(), ResponseCreateSeatDoc.get())
-			));
-	}
-
-	@Test
-	@WithMockUser(roles = {"USER", "ADMIN"})
-	@DisplayName("선택 된 스케줄에 예약된 좌석 정보 조회 - id 리스트 반환")
-	void testFindReservedIdListByScheduleId() throws Exception {
-		Long scheduleId = 1L;
-
-		List<ResponseFindSeat> seatList = List.of(
-			new ResponseFindSeat(0, 0),
-			new ResponseFindSeat(0, 1));
-
-		given(reservationService.findReservePossibleSeatList(scheduleId)).willReturn(seatList);
-
-		mockMvc.perform(get(RESERVED_SEAT_URL + "/{scheduleId}/possible", scheduleId)
-			.with(SecurityMockMvcRequestPostProcessors.csrf())
-		)
-			.andExpect(status().isOk())
-			.andDo(document("reserved-seat-possible",
-				responseFields()
-					.andWithPrefix(ARRAY_PREFIX.getField(), ResponseCreateSeatDoc.get())
+					.andWithPrefix(ARRAY_PREFIX.getField(), ResponseFindReservedSeatDoc.get())
 			));
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/service/ReservationServiceTest.java
@@ -11,19 +11,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
 import prgrms.marco.be02marbox.domain.movie.service.utils.MovieConverter;
+import prgrms.marco.be02marbox.domain.reservation.dto.ResponseFindReservedSeat;
 import prgrms.marco.be02marbox.domain.reservation.repository.RepositoryTestUtil;
 import prgrms.marco.be02marbox.domain.theater.Schedule;
-import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindSeat;
 import prgrms.marco.be02marbox.domain.theater.service.ScheduleService;
 import prgrms.marco.be02marbox.domain.theater.service.SeatService;
 import prgrms.marco.be02marbox.domain.theater.service.utils.ScheduleConverter;
-import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
 
 @Import({ReservationService.class,
 	ReservedSeatService.class,
 	SeatService.class,
 	ScheduleService.class,
-	SeatConverter.class,
 	ScheduleConverter.class,
 	MovieConverter.class
 })
@@ -44,8 +42,9 @@ class ReservationServiceTest extends RepositoryTestUtil {
 		int reservedCount = 2;
 		Schedule schedule = saveSeatAndReserveSeat(totalSeatCount, reservedCount);
 
-		List<ResponseFindSeat> reservePossibleSeats = reservationService.findReservePossibleSeatList(schedule.getId());
-		assertThat(reservePossibleSeats).hasSize(totalSeatCount - reservedCount);
+		List<ResponseFindReservedSeat> reservePossibleSeats = reservationService.findReservePossibleSeatList(
+			schedule.getId());
+		assertThat(reservePossibleSeats).hasSize(totalSeatCount);
 	}
 
 	@Test
@@ -53,16 +52,8 @@ class ReservationServiceTest extends RepositoryTestUtil {
 	void testFindReservePossibleSeatsEmpty() {
 		Schedule schedule = saveSchedule();
 
-		List<ResponseFindSeat> reservePossibleSeats = reservationService.findReservePossibleSeatList(schedule.getId());
-		assertThat(reservePossibleSeats).isEmpty();
-	}
-
-	@Test
-	@DisplayName("모든 좌석이 예매 된 경우 - 비어있는 리스트 반환")
-	void testFindReservePossibleSeatsAllReserved() {
-		Schedule schedule = saveSeatAndReserveSeat(2, 2);
-
-		List<ResponseFindSeat> reservePossibleSeats = reservationService.findReservePossibleSeatList(schedule.getId());
+		List<ResponseFindReservedSeat> reservePossibleSeats = reservationService.findReservePossibleSeatList(
+			schedule.getId());
 		assertThat(reservePossibleSeats).isEmpty();
 	}
 
@@ -72,7 +63,8 @@ class ReservationServiceTest extends RepositoryTestUtil {
 		int totalSeatCount = 3;
 		Schedule schedule = saveSeatAndReserveSeat(totalSeatCount, 0);
 
-		List<ResponseFindSeat> reservePossibleSeats = reservationService.findReservePossibleSeatList(schedule.getId());
+		List<ResponseFindReservedSeat> reservePossibleSeats = reservationService.findReservePossibleSeatList(
+			schedule.getId());
 		assertThat(reservePossibleSeats).hasSize(totalSeatCount);
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/service/ReservedSeatServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/service/ReservedSeatServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,27 +14,25 @@ import org.springframework.context.annotation.Import;
 import prgrms.marco.be02marbox.domain.reservation.ReservedSeat;
 import prgrms.marco.be02marbox.domain.reservation.repository.RepositoryTestUtil;
 import prgrms.marco.be02marbox.domain.theater.Schedule;
-import prgrms.marco.be02marbox.domain.theater.dto.ResponseFindSeat;
-import prgrms.marco.be02marbox.domain.theater.service.utils.SeatConverter;
 
-@Import({ReservedSeatService.class, SeatConverter.class})
+@Import({ReservedSeatService.class})
 class ReservedSeatServiceTest extends RepositoryTestUtil {
 	@Autowired
 	ReservedSeatService reservedSeatService;
 
 	@Test
 	@DisplayName("스케줄 id로 좌석정보를 조회할 수 있다.")
-	void testFindByScheduleId() {
+	void testFindReservedIdListByScheduleId() {
 		int seatCount = 3;
 		Schedule schedule = saveReservedSeatMultiSeat(seatCount);
 
-		List<ResponseFindSeat> seatList = reservedSeatService.findByScheduleId(schedule.getId());
+		Set<Long> seatList = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
 		assertThat(seatList).hasSize(seatCount);
 	}
 
 	@Test
 	@DisplayName("스케줄 id로 좌석정보를 조회할 수 있다. - 여러 스케줄이 저장되어 있는 경우")
-	void testFindByScheduleId_multiSchedule() {
+	void testFindReservedIdListByScheduleIdMultiSchedule() {
 		int cnt = 1;
 		int cnt2 = 2;
 		int cnt3 = 3;
@@ -44,9 +43,9 @@ class ReservedSeatServiceTest extends RepositoryTestUtil {
 
 		List<ReservedSeat> all = reservedSeatRepository.findAll();
 
-		List<ResponseFindSeat> seatList = reservedSeatService.findByScheduleId(schedule.getId());
-		List<ResponseFindSeat> seatList2 = reservedSeatService.findByScheduleId(schedule2.getId());
-		List<ResponseFindSeat> seatList3 = reservedSeatService.findByScheduleId(schedule3.getId());
+		Set<Long> seatList = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
+		Set<Long> seatList2 = reservedSeatService.findReservedIdListByScheduleId(schedule2.getId());
+		Set<Long> seatList3 = reservedSeatService.findReservedIdListByScheduleId(schedule3.getId());
 
 		assertAll(
 			() -> assertThat(all).hasSize(cnt + cnt2 + cnt3),
@@ -58,40 +57,40 @@ class ReservedSeatServiceTest extends RepositoryTestUtil {
 
 	@Test
 	@DisplayName("저장되지 않은 scheduleId로 조회하는 경우")
-	void testFindByScheduleId_wrongScheduleId() {
+	void testFindReservedIdListByScheduleIdWrongScheduleId() {
 		saveReservedSeat();
 
-		List<ResponseFindSeat> seatList = reservedSeatService.findByScheduleId(-1L);
+		Set<Long> seatList = reservedSeatService.findReservedIdListByScheduleId(-1L);
 		assertThat(seatList).isEmpty();
 	}
 
 	@Test
-	@DisplayName("예매 좌석 조회")
-	void testFindReservePossibleSeats() {
+	@DisplayName("예매 좌석이 존재하는 경우")
+	void testFindReservedIdListByScheduleIdExist() {
 		int totalSeatCount = 5;
 		int reservedCount = 2;
 		Schedule schedule = saveSeatAndReserveSeat(totalSeatCount, reservedCount);
 
-		List<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
+		Set<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
 		assertThat(reservePossibleSeats).hasSize(reservedCount);
 	}
 
 	@Test
 	@DisplayName("예매 좌석 없는 경우")
-	void testFindReservePossibleSeatsEmpty() {
+	void testFindReservedIdListByScheduleIdEmpty() {
 		Schedule schedule = saveSchedule();
 
-		List<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
+		Set<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
 		assertThat(reservePossibleSeats).isEmpty();
 	}
 
 	@Test
 	@DisplayName("모든 좌석이 예매 된 경우")
-	void testFindReservePossibleSeatsAllReserved() {
+	void testFindReservedIdListByScheduleIdAllReserved() {
 		int totalSeatCount = 2;
 		Schedule schedule = saveSeatAndReserveSeat(totalSeatCount, totalSeatCount);
 
-		List<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
+		Set<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
 		assertThat(reservePossibleSeats).hasSize(totalSeatCount);
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/dto/document/ResponseFindReservedSeatDoc.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/dto/document/ResponseFindReservedSeatDoc.java
@@ -8,15 +8,17 @@ import java.util.List;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 
-public enum ResponseCreateSeatDoc {
+public enum ResponseFindReservedSeatDoc {
+	ARRAY_PREFIX(ARRAY, "[].", "예매 좌석 리스트"),
 	ROW(NUMBER, "row", "행"),
-	COL(NUMBER, "col", "열");
+	COL(NUMBER, "col", "열"),
+	RESERVED(BOOLEAN, "reserved", "예약 유무");
 
 	private JsonFieldType type;
 	private final String field;
 	private final String description;
 
-	ResponseCreateSeatDoc(JsonFieldType type, String field, String description) {
+	ResponseFindReservedSeatDoc(JsonFieldType type, String field, String description) {
 		this.type = type;
 		this.field = field;
 		this.description = description;
@@ -42,7 +44,8 @@ public enum ResponseCreateSeatDoc {
 	public static List<FieldDescriptor> get() {
 		return List.of(
 			ROW.getFieldDescriptor(),
-			COL.getFieldDescriptor()
+			COL.getFieldDescriptor(),
+			RESERVED.getFieldDescriptor()
 		);
 	}
 }

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/SeatServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/SeatServiceTest.java
@@ -33,7 +33,8 @@ class SeatServiceTest extends RepositoryTestUtil {
 		Schedule schedule = saveSeatAndReserveSeat(totalSeatCount, reservedCount);
 
 		Set<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
-		List<ResponseFindReservedSeat> reservedSeat = seatService.findReservedSeat(schedule.getTheaterRoom().getId(),
+		List<ResponseFindReservedSeat> reservedSeat = seatService.findAvailableSeatList(
+			schedule.getTheaterRoom().getId(),
 			reservePossibleSeats);
 
 		long resultReservedCount = reservedSeat.stream()

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/service/SeatServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/service/SeatServiceTest.java
@@ -1,0 +1,48 @@
+package prgrms.marco.be02marbox.domain.theater.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import prgrms.marco.be02marbox.domain.reservation.dto.ResponseFindReservedSeat;
+import prgrms.marco.be02marbox.domain.reservation.repository.RepositoryTestUtil;
+import prgrms.marco.be02marbox.domain.reservation.service.ReservedSeatService;
+import prgrms.marco.be02marbox.domain.theater.Schedule;
+
+@Import({ReservedSeatService.class, SeatService.class})
+class SeatServiceTest extends RepositoryTestUtil {
+
+	@Autowired
+	ReservedSeatService reservedSeatService;
+
+	@Autowired
+	SeatService seatService;
+
+	@Test
+	@DisplayName("예약 좌석 정보를 조회한다.")
+	void testFindReservedSeat() {
+		int totalSeatCount = 5;
+		int reservedCount = 3;
+		Schedule schedule = saveSeatAndReserveSeat(totalSeatCount, reservedCount);
+
+		Set<Long> reservePossibleSeats = reservedSeatService.findReservedIdListByScheduleId(schedule.getId());
+		List<ResponseFindReservedSeat> reservedSeat = seatService.findReservedSeat(schedule.getTheaterRoom().getId(),
+			reservePossibleSeats);
+
+		long resultReservedCount = reservedSeat.stream()
+			.filter(responseFindReservedSeat -> responseFindReservedSeat.reserved())
+			.count();
+
+		assertAll(
+			() -> assertThat(reservedSeat).hasSize(totalSeatCount),
+			() -> assertThat(reservedCount).isEqualTo(resultReservedCount)
+		);
+	}
+}


### PR DESCRIPTION
## 개요
- 예매좌석 조회 API 통합

## 변경 전
- 2개의 API 제공
  - 스케줄 별 예매(되어있는)좌석 조회
  - 스케줄 별 예매(가능한)좌석 조회

## 변경 후
- 예약 유무 필드를 포함하여 전체 좌석 반환
  - 이게 더 MVP에 적합한 API인 것 같다.
  - [피드백 링크](https://github.com/prgrms-be-devcourse/BE-02-MarBox/pull/128/files/12d516ac4019ce5235022c31401bed18d1e99231#diff-712e1ddb6eda2e6e36804fa547f9d32d92e5c08eaf0f97acbfa7458a64703d6d)

![image](https://user-images.githubusercontent.com/26343023/177307368-ae0ab53b-9751-4ded-ae6f-0c59d67077d9.png)