### PR TITLE
[#150] swagger Restdocs 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.asciidoctor.convert' version '1.5.8'
     id 'java'
     id 'checkstyle'
+    id 'com.epages.restdocs-api-spec' version '0.16.0'
 }
 
 group = 'prgrms.marco'
@@ -38,6 +39,8 @@ dependencies {
 
     implementation 'mysql:mysql-connector-java'
 
+    implementation "io.springfox:springfox-boot-starter:3.0.0"
+
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     runtimeOnly 'com.h2database:h2'
@@ -46,6 +49,7 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-inline:4.6.1'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.0'
 }
 
 tasks.named('test') {
@@ -56,4 +60,17 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+openapi3 {
+    server = 'http://localhost:8080'
+    title = 'Marbox API'
+    description = 'Marbox API description'
+    version = '1.0.0'
+    format = 'yaml'
+
+    copy {
+        from 'build/api-spec'
+        into 'src/main/resources/static/docs'
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,10 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+  marbox-swagger:
+    image: swaggerapi/swagger-ui
+    container_name: marbox-swagge
+    ports:
+      - 8081:8080
+    environment:
+      API_URL: http://localhost:8080/docs/openapi3.yaml

--- a/src/docs/asciidoc/schedule.adoc
+++ b/src/docs/asciidoc/schedule.adoc
@@ -27,6 +27,7 @@ include::{snippets}/schedule-get-current-movies/response-fields.adoc[]
 
 .Request
 include::{snippets}/schedule-get-movie-and-date-in-theater/http-request.adoc[]
+include::{snippets}/schedule-get-movie-and-date-in-theater/request-parameters.adoc[]
 
 .Response
 include::{snippets}/schedule-get-movie-and-date-in-theater/http-response.adoc[]
@@ -36,6 +37,7 @@ include::{snippets}/schedule-get-movie-and-date-in-theater/response-fields.adoc[
 
 .Request
 include::{snippets}/schedule-get-movie-by-date-and-theater/http-request.adoc[]
+include::{snippets}/schedule-get-movie-by-date-and-theater/request-parameters.adoc[]
 
 .Response
 include::{snippets}/schedule-get-movie-by-date-and-theater/http-response.adoc[]
@@ -45,6 +47,7 @@ include::{snippets}/schedule-get-movie-by-date-and-theater/response-fields.adoc[
 
 .Request
 include::{snippets}/schedule-get-timeList-by-movie-and-theater-and-date/http-request.adoc[]
+include::{snippets}/schedule-get-timeList-by-movie-and-theater-and-date/request-parameters.adoc[]
 
 .Response
 include::{snippets}/schedule-get-timeList-by-movie-and-theater-and-date/http-response.adoc[]

--- a/src/main/java/prgrms/marco/be02marbox/config/CorsConfig.java
+++ b/src/main/java/prgrms/marco/be02marbox/config/CorsConfig.java
@@ -1,0 +1,14 @@
+package prgrms.marco.be02marbox.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**");
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/config/SwaggerConfig.java
+++ b/src/main/java/prgrms/marco/be02marbox/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package prgrms.marco.be02marbox.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@Configuration
+public class SwaggerConfig {
+
+	@Bean
+	public Docket api() {
+		return new Docket(DocumentationType.SWAGGER_2)
+			.select()
+			.apis(RequestHandlerSelectors.any())
+			.paths(PathSelectors.any())
+			.build();
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/config/WebSecurityConfigure.java
+++ b/src/main/java/prgrms/marco/be02marbox/config/WebSecurityConfigure.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -61,7 +62,8 @@ public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
 		http
 			.authorizeRequests()
 			.antMatchers(HttpMethod.POST, "/users/sign-up", "/users/sign-in", "/users/refresh").permitAll()
-			.antMatchers(HttpMethod.GET, "/theaters", "/schedules/current-movies", "/schedules").permitAll()
+			.antMatchers(HttpMethod.GET, "/theaters", "/schedules/current-movies", "/schedules", "/swagger-ui/**",
+				"/swagger-resources/**", "/docs/**").permitAll()
 			.anyRequest().hasAnyRole("ADMIN")
 			.and()
 
@@ -92,5 +94,12 @@ public class WebSecurityConfigure extends WebSecurityConfigurerAdapter {
 			.exceptionHandling()
 			.authenticationEntryPoint(authenticationEntryPoint())
 			.accessDeniedHandler(accessDeniedHandler());
+	}
+
+	@Override
+	public void configure(WebSecurity web) throws Exception {
+		web.ignoring().antMatchers("/v2/api-docs", "/configuration/ui",
+			"/swagger-resources", "/configuration/security",
+			"/swagger-ui.html", "/webjars/**", "/swagger/**");
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   profiles:
     default: dev
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
 
 jwt:
   header: access-token

--- a/src/main/resources/static/docs/openapi3.yaml
+++ b/src/main/resources/static/docs/openapi3.yaml
@@ -1,0 +1,480 @@
+openapi: 3.0.1
+info:
+  title: Marbox API
+  description: Marbox API description
+  version: 1.0.0
+servers:
+- url: http://localhost:8080
+tags: []
+paths:
+  /reserved-seats/{scheduleId}:
+    get:
+      tags:
+      - reserved-seats
+      operationId: reserved-seat
+      parameters:
+      - name: scheduleId
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/reserved-seats-scheduleId1854644414'
+              examples:
+                reserved-seat:
+                  value: "[{\"row\":0,\"col\":0,\"reserved\":false},{\"row\":0,\"\
+                    col\":1,\"reserved\":true}]"
+  /schedules:
+    get:
+      tags:
+      - schedules
+      operationId: schedule-get-
+      parameters:
+      - name: theaterId
+        in: query
+        description: 영화관 ID
+        required: false
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: 날짜
+        required: false
+        schema:
+          type: string
+      - name: movieId
+        in: query
+        description: 영화 ID
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/schedules588914321'
+              examples:
+                schedule-get-movie-and-date-in-theater:
+                  value: "{\"movieList\":[{\"name\":\"영화1\",\"limitAge\":\"CHILD\"\
+                    ,\"genre\":\"ACTION\",\"runningTime\":100,\"posterImgLocation\"\
+                    :\"test/location\"},{\"name\":\"영화2\",\"limitAge\":\"ADULT\",\"\
+                    genre\":\"ROMANCE\",\"runningTime\":120,\"posterImgLocation\"\
+                    :\"test/location\"},{\"name\":\"영화3\",\"limitAge\":\"CHILD\",\"\
+                    genre\":\"ANIMATION\",\"runningTime\":150,\"posterImgLocation\"\
+                    :\"test/location\"}],\"theaterList\":[],\"dateList\":[\"2022-07-06\"\
+                    ,\"2022-07-07\"],\"timeList\":[]}"
+                schedule-get-movie-by-date-and-theater:
+                  value: "{\"movieList\":[{\"name\":\"영화1\",\"limitAge\":\"CHILD\"\
+                    ,\"genre\":\"ACTION\",\"runningTime\":100,\"posterImgLocation\"\
+                    :\"test/location\"},{\"name\":\"영화2\",\"limitAge\":\"ADULT\",\"\
+                    genre\":\"ROMANCE\",\"runningTime\":120,\"posterImgLocation\"\
+                    :\"test/location\"},{\"name\":\"영화3\",\"limitAge\":\"CHILD\",\"\
+                    genre\":\"ANIMATION\",\"runningTime\":150,\"posterImgLocation\"\
+                    :\"test/location\"}],\"theaterList\":[],\"dateList\":[],\"timeList\"\
+                    :[]}"
+                schedule-get-timeList-by-movie-and-theater-and-date:
+                  value: "{\"movieList\":[],\"theaterList\":[],\"dateList\":[],\"\
+                    timeList\":[{\"theaterRoomName\":\"상영관1\",\"totalSeatCount\":75,\"\
+                    startTimeList\":[\"09:30:00\",\"14:25:00\",\"16:45:00\",\"19:30:00\"\
+                    ]},{\"theaterRoomName\":\"상영관2\",\"totalSeatCount\":100,\"startTimeList\"\
+                    :[\"20:40:00\"]}]}"
+    post:
+      tags:
+      - schedules
+      operationId: schedule-save
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/schedules266360835'
+            examples:
+              schedule-save:
+                value: "{\"theaterRoomId\":1,\"movieId\":1,\"startTime\":\"2022-07-06T16:28:34.850918\"\
+                  ,\"endTime\":\"2022-07-06T16:28:34.850938\"}"
+      responses:
+        "201":
+          description: "201"
+  /schedules/current-movies:
+    get:
+      tags:
+      - schedules
+      operationId: schedule-get-current-movies
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/schedules-current-movies1672648316'
+              examples:
+                schedule-get-current-movies:
+                  value: "[{\"name\":\"테스트1\",\"limitAge\":\"CHILD\",\"genre\":\"\
+                    ACTION\",\"runningTime\":100,\"posterImgLocation\":\"test/location\"\
+                    },{\"name\":\"테스트2\",\"limitAge\":\"CHILD\",\"genre\":\"ROMANCE\"\
+                    ,\"runningTime\":150,\"posterImgLocation\":\"test/location\"},{\"\
+                    name\":\"테스트3\",\"limitAge\":\"ADULT\",\"genre\":\"ACTION\",\"\
+                    runningTime\":120,\"posterImgLocation\":\"test/location\"}]"
+  /theater-rooms:
+    post:
+      tags:
+      - theater-rooms
+      operationId: theater-room-save
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/theater-rooms-1243494910'
+            examples:
+              theater-room-save:
+                value: "{\"theaterId\":1,\"name\":\"A관\",\"requestCreateSeats\":[{\"\
+                  row\":0,\"col\":1},{\"row\":0,\"col\":0}]}"
+      responses:
+        "201":
+          description: "201"
+  /theaters:
+    get:
+      tags:
+      - theaters
+      operationId: theater-find-all
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theaters-region486549215'
+              examples:
+                theater-find-all:
+                  value: "[{\"region\":\"SEOUL\",\"theaterName\":\"theater0\"},{\"\
+                    region\":\"SEOUL\",\"theaterName\":\"theater1\"},{\"region\":\"\
+                    SEOUL\",\"theaterName\":\"theater2\"},{\"region\":\"SEOUL\",\"\
+                    theaterName\":\"theater3\"},{\"region\":\"SEOUL\",\"theaterName\"\
+                    :\"theater4\"},{\"region\":\"SEOUL\",\"theaterName\":\"theater5\"\
+                    },{\"region\":\"SEOUL\",\"theaterName\":\"theater6\"},{\"region\"\
+                    :\"SEOUL\",\"theaterName\":\"theater7\"},{\"region\":\"SEOUL\"\
+                    ,\"theaterName\":\"theater8\"},{\"region\":\"SEOUL\",\"theaterName\"\
+                    :\"theater9\"}]"
+    post:
+      tags:
+      - theaters
+      operationId: theater-save
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/theaters582794890'
+            examples:
+              theater-save:
+                value: "{\"region\":\"SEOUL\",\"name\":\"theater0\"}"
+      responses:
+        "201":
+          description: "201"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theaters-theaterId1673730357'
+              examples:
+                theater-save:
+                  value: "{\"region\":\"SEOUL\",\"theaterName\":\"theater0\"}"
+  /theaters/region:
+    get:
+      tags:
+      - theaters
+      operationId: theater-find-by-region
+      parameters:
+      - name: name
+        in: query
+        description: 지역
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theaters-region486549215'
+              examples:
+                theater-find-by-region:
+                  value: "[{\"region\":\"SEOUL\",\"theaterName\":\"theater0\"}]"
+  /theaters/{theaterId}:
+    get:
+      tags:
+      - theaters
+      operationId: theater-find
+      parameters:
+      - name: theaterId
+        in: path
+        description: 영화관 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theaters-theaterId1673730357'
+              examples:
+                theater-find:
+                  value: "{\"region\":\"SEOUL\",\"theaterName\":\"theater0\"}"
+  /users/refresh:
+    post:
+      tags:
+      - users
+      operationId: user-refresh
+      responses:
+        "204":
+          description: "204"
+          headers:
+            Set-Cookie:
+              description: "new access token, new refresh token"
+              schema:
+                type: string
+  /users/sign-in:
+    post:
+      tags:
+      - users
+      operationId: user-sign-in
+      parameters:
+      - name: Content-Type
+        in: header
+        description: 컨텐츠 타입
+        required: true
+        schema:
+          type: string
+        example: application/json;charset=UTF-8
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/users-sign-in32710318'
+            examples:
+              user-sign-in:
+                value: "{\"email\":\"pang@mail.com\",\"password\":\"1234\"}"
+      responses:
+        "204":
+          description: "204"
+          headers:
+            Set-Cookie:
+              description: 쿠키 세팅
+              schema:
+                type: string
+  /users/sign-up:
+    post:
+      tags:
+      - users
+      operationId: user-sign-up
+      parameters:
+      - name: Content-Type
+        in: header
+        description: 컨텐츠 타입
+        required: true
+        schema:
+          type: string
+        example: application/json;charset=UTF-8
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/users-sign-up2102361656'
+            examples:
+              user-sign-up:
+                value: "{\"email\":\"pang@mail.com\",\"password\":\"1234\",\"name\"\
+                  :\"pang\",\"role\":\"ROLE_ADMIN\"}"
+      responses:
+        "201":
+          description: "201"
+          headers:
+            Location:
+              description: 로그인 API 위치
+              schema:
+                type: string
+components:
+  schemas:
+    theater-rooms-1243494910:
+      type: object
+      properties:
+        theaterId:
+          type: number
+          description: 영화관 id
+        name:
+          type: string
+          description: 상영관 이름
+        requestCreateSeats:
+          type: array
+          items:
+            type: object
+            properties:
+              col:
+                type: number
+                description: 열
+              row:
+                type: number
+                description: 행
+    schedules266360835:
+      type: object
+      properties:
+        theaterRoomId:
+          type: number
+          description: 상영관 ID
+        startTime:
+          type: string
+          description: 영화 시작 날짜와 시간
+        movieId:
+          type: number
+          description: 영화 ID
+        endTime:
+          type: string
+          description: 영화 종료 날짜와 시간
+    reserved-seats-scheduleId1854644414:
+      type: array
+      items:
+        type: object
+        properties:
+          col:
+            type: number
+            description: 열
+          reserved:
+            type: boolean
+            description: 예약 유무
+          row:
+            type: number
+            description: 행
+    theaters-theaterId1673730357:
+      type: object
+      properties:
+        theaterName:
+          type: string
+          description: 영화관 이름
+        region:
+          type: string
+          description: 지역
+    theaters582794890:
+      type: object
+      properties:
+        name:
+          type: string
+          description: 영화관 이름
+        region:
+          type: string
+          description: 지역
+    users-sign-up2102361656:
+      type: object
+      properties:
+        password:
+          type: string
+          description: 사용자 비밀번호
+        role:
+          type: string
+          description: 사용자 역할
+        name:
+          type: string
+          description: 사용자 이름
+        email:
+          type: string
+          description: 사용자 이메일
+    schedules588914321:
+      type: object
+      properties:
+        theaterList:
+          type: array
+          description: 빈 배열
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        timeList:
+          type: array
+          description: 상영 시간 정보
+          items:
+            type: object
+            properties:
+              startTimeList:
+                type: array
+                description: 상영관의 영화 시작 시간 배열
+                items:
+                  oneOf:
+                  - type: object
+                  - type: boolean
+                  - type: string
+                  - type: number
+              theaterRoomName:
+                type: string
+                description: 상영관 이름
+              totalSeatCount:
+                type: number
+                description: 상영관 총 좌석 수
+        dateList:
+          type: array
+          description: 빈 배열
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        movieList:
+          type: array
+          description: 빈 배열
+          items:
+            type: object
+            properties:
+              posterImgLocation:
+                type: string
+                description: 포스터 이미지 경로
+              genre:
+                type: string
+                description: 장르
+              name:
+                type: string
+                description: 영화 이름
+              runningTime:
+                type: number
+                description: 상영시간
+              limitAge:
+                type: string
+                description: 영화 관람 등급
+    users-sign-in32710318:
+      type: object
+      properties:
+        password:
+          type: string
+          description: 사용자 비밀번호
+        email:
+          type: string
+          description: 사용자 이메일
+    schedules-current-movies1672648316:
+      type: array
+      items:
+        type: object
+        properties:
+          posterImgLocation:
+            type: string
+            description: 포스터 이미지 경로
+          genre:
+            type: string
+            description: 장르
+          name:
+            type: string
+            description: 영화 이름
+          runningTime:
+            type: number
+            description: 상영시간
+          limitAge:
+            type: string
+            description: 연령 제한
+    theaters-region486549215:
+      type: object

--- a/src/test/java/prgrms/marco/be02marbox/domain/reservation/controller/ReservedSeatControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/reservation/controller/ReservedSeatControllerTest.java
@@ -1,8 +1,8 @@
 package prgrms.marco.be02marbox.domain.reservation.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static prgrms.marco.be02marbox.domain.theater.dto.document.ResponseCreateSeatDoc.*;

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/ScheduleControllerTest.java
@@ -1,12 +1,13 @@
 package prgrms.marco.be02marbox.domain.theater.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+// import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -149,6 +150,7 @@ class ScheduleControllerTest {
 				.param("theaterId", "1"))
 			.andExpect(status().isOk())
 			.andDo(document("schedule-get-movie-and-date-in-theater",
+				requestParameters(parameterWithName("theaterId").optional().description("영화관 ID")),
 				responseFields(
 					fieldWithPath("movieList[]").type(JsonFieldType.ARRAY).description("영화 리스트"),
 					fieldWithPath("movieList[].name").type(JsonFieldType.STRING).description("영화 이름"),
@@ -197,6 +199,9 @@ class ScheduleControllerTest {
 				.param("date", LocalDate.now().toString()))
 			.andExpect(status().isOk())
 			.andDo(document("schedule-get-movie-by-date-and-theater",
+				requestParameters(
+					parameterWithName("theaterId").optional().description("영화관 ID"),
+					parameterWithName("date").optional().description("날짜")),
 				responseFields(
 					fieldWithPath("movieList[]").type(JsonFieldType.ARRAY).description("영화 리스트"),
 					fieldWithPath("movieList[].name").type(JsonFieldType.STRING).description("영화 이름"),
@@ -239,6 +244,10 @@ class ScheduleControllerTest {
 				.param("date", LocalDate.now().toString()))
 			.andExpect(status().isOk())
 			.andDo(document("schedule-get-timeList-by-movie-and-theater-and-date",
+				requestParameters(
+					parameterWithName("movieId").optional().description("영화 ID"),
+					parameterWithName("theaterId").optional().description("영화관 ID"),
+					parameterWithName("date").optional().description("날짜")),
 				responseFields(
 					fieldWithPath("timeList[]").type(JsonFieldType.ARRAY).description("상영 시간 정보"),
 					fieldWithPath("timeList[].theaterRoomName").type(JsonFieldType.STRING).description("상영관 이름"),

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterControllerTest.java
@@ -1,9 +1,9 @@
 package prgrms.marco.be02marbox.domain.theater.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;	// 변경 후
 import static org.mockito.BDDMockito.*;
 import static org.springframework.http.MediaType.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;	// 변경 후
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;

--- a/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/theater/controller/TheaterRoomControllerTest.java
@@ -1,9 +1,9 @@
 package prgrms.marco.be02marbox.domain.theater.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static prgrms.marco.be02marbox.domain.exception.custom.Message.*;
 import static prgrms.marco.be02marbox.domain.theater.dto.document.RequestCreateTheaterRoomDoc.*;
@@ -64,16 +64,16 @@ class TheaterRoomControllerTest {
 		given(theaterCommonService.saveTheaterRoomWithSeatList(requestDto)).willReturn(theaterId);
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
-			.with(SecurityMockMvcRequestPostProcessors.csrf())
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(requestDto))
-		)
+				.with(SecurityMockMvcRequestPostProcessors.csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto))
+			)
 			.andExpect(status().isCreated())
 			.andExpect(redirectedUrl(THEATER_ROOM_SAVE_URL + "/" + theaterId))
 			.andDo(document("theater-room-save",
-				requestFields()
-					.andWithPrefix(SEAT_LIST_PREFIX.getField(), RequestCreateSeatDoc.get())
-					.and(RequestCreateTheaterRoomDoc.get())
+					requestFields()
+						.andWithPrefix(SEAT_LIST_PREFIX.getField(), RequestCreateSeatDoc.get())
+						.and(RequestCreateTheaterRoomDoc.get())
 				)
 			);
 	}
@@ -89,10 +89,10 @@ class TheaterRoomControllerTest {
 			new IllegalArgumentException(INVALID_THEATER_EXP_MSG.getMessage()));
 
 		mockMvc.perform(post(THEATER_ROOM_SAVE_URL)
-			.with(SecurityMockMvcRequestPostProcessors.csrf())
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(requestDto))
-		)
+				.with(SecurityMockMvcRequestPostProcessors.csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto))
+			)
 			.andExpect(status().isBadRequest()
 			);
 	}

--- a/src/test/java/prgrms/marco/be02marbox/domain/user/UserIntegrationTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/user/UserIntegrationTest.java
@@ -1,7 +1,7 @@
 package prgrms.marco.be02marbox.domain.user;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,6 +15,9 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate.dialect: org.hibernate.dialect.H2Dialect
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
 
 jwt:
   header: testToken


### PR DESCRIPTION
## 개요
- swagger restdocs 연동

## 변경사항(Optional)
- WebSecurityConfigure -> Swagger 관련 permitAll 추가 
- docker-compose.yml -> swagger 추가
- controllerTest 클래스 -> import 변경
- application.yml -> ant_path_mather 추가 [관련 설명](https://skmouse.tistory.com/entry/SpringBoot-Swagger-%EC%97%90%EB%9F%AC-Failed-to-start-bean-documentationPluginsBootstrapper-nested-exception-is-javalangNullPointerException)

## 사용방법(Optional)
- gradle 탭 -> documentation 폴더 -> openapi3 실행 후 build
- swagger 접속 방법 -> 도커 swagger 실행, 애플리케이션 실행 후 localhost:8081 접속

## 기타
- localhost:8081 접속
![image](https://user-images.githubusercontent.com/43159295/177532328-0183b03e-e789-4074-a53d-e4127ffef71f.png)
