### PR TITLE
[#183] 개발용, 테스트 서버용 docker-compose 분리

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,12 @@
+version: "3.7"
+services:
+  marbox-redis:
+    image: redis:alpine
+    command: redis-server --requirepass marbox --port 6379
+    container_name: marbox-redis
+    hostname: marbox-redis
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## 개요
- 개발용, 테스트 서버용 docker-compose 분리

## 추가기능
- Test Server (AWS EC2)에서 사용할 docker-compose.test.yml 파일 추가

## 사용방법(Optional)
- AWS EC2에서 docker-compose.test.yml을 이용해 redis container 실행