### PR TITLE
[#185] 파일 업로드 S3 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ build/
 !**/src/test/**/build/
 .DS_Store
 
-
 ### 포스터가 저장되는 디렉토리 ###
 posters/
+
+### aws 설정파일 ###
+application-aws.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
     implementation "io.springfox:springfox-boot-starter:3.0.0"
 
+    // s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/prgrms/marco/be02marbox/aws/S3Upload.java
+++ b/src/main/java/prgrms/marco/be02marbox/aws/S3Upload.java
@@ -1,0 +1,149 @@
+package prgrms.marco.be02marbox.aws;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+@Component
+public class S3Upload {
+	private static final Logger log = LoggerFactory.getLogger(S3Upload.class);
+	private static final String POSTER_DIR = "posters";
+	private static final String FILE_CONVERT_EXP_MSG = "MultipartFile -> File로 전환이 실패했습니다.";
+	private static final String DELETE_FILE_MSG = "파일이 삭제되었습니다.";
+	private static final String DELETE_FILE_EXP_MSG = "파일이 삭제되지 못했습니다.";
+	private static final String FILE_EXTENSION_SEPARATOR = ".";
+
+	private final AmazonS3Client amazonS3Client;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	@Value("${cloud.aws.s3.save-dir-prefix}")
+	private String saveDirPrefix;
+
+	public S3Upload(AmazonS3Client amazonS3Client) {
+		this.amazonS3Client = amazonS3Client;
+	}
+
+	/**
+	 * 영화 포스터를 S3에 업로드한다.
+	 * @param multipartFile 포스터 첨부파일
+	 * @param movieId 생성 된 영화 ID
+	 * @return 파일이 생성 된 경로
+	 * @throws IOException 파일 변환 실패
+	 */
+	public String upload(MultipartFile multipartFile, Long movieId) throws IOException {
+		String fullPath = saveDirPrefix + POSTER_DIR;
+		makeDirectory(fullPath);
+		String extension = getFileExtension(multipartFile.getOriginalFilename());
+		String fileName = generateNewFileName(fullPath, extension, movieId);
+
+		File uploadFile = convert(multipartFile, fileName)
+			.orElseThrow(() -> new IllegalArgumentException(FILE_CONVERT_EXP_MSG));
+		return upload(uploadFile, fileName);
+	}
+
+	/**
+	 * movieId와 환경 별 prefix를 통해 파일을 생성한다.
+	 * @param uploadFile S3로 전송할 파일
+	 * @return 생성된 파일 Url
+	 */
+	private String upload(File uploadFile, String fileName) {
+		String uploadImageUrl = putS3(uploadFile, fileName);
+		removeNewFile(uploadFile);
+		return uploadImageUrl;
+	}
+
+	/**
+	 * S3로 파일을 전송한다.
+	 * @param uploadFile S3로 전송할 파일
+	 * @param fileName 파일
+	 * @return 생성된 파일 Url
+	 */
+	private String putS3(File uploadFile, String fileName) {
+		amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(
+			CannedAccessControlList.PublicRead));
+		return amazonS3Client.getUrl(bucket, fileName).toString();
+	}
+
+	/**
+	 * local에 받아온 파일은 S3에 전송 후 삭제한다.
+	 * @param targetFile 로컬에 생성된 파일
+	 */
+	private void removeNewFile(File targetFile) {
+		if (targetFile.delete()) {
+			log.info(DELETE_FILE_MSG);
+		} else {
+			log.info(DELETE_FILE_EXP_MSG);
+		}
+	}
+
+	/**
+	 * MultipartFile -> File 변환.
+	 * @param file 포스터 첨부파일
+	 * @param fileName 파일 명
+	 * @return 로컬에 생성 된 파일
+	 * @throws IOException 파일 변환 실패
+	 */
+	private Optional<File> convert(MultipartFile file, String fileName) throws IOException {
+		File convertFile = new File(fileName);
+		if (convertFile.createNewFile()) {
+			try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+				fos.write(file.getBytes());
+			}
+			return Optional.of(convertFile);
+		}
+
+		return Optional.empty();
+	}
+
+	/**
+	 * 생성될 파일 문자열을 경로를 포함하여 만든다
+	 * @param fullPath 파일 경로
+	 * @param extension 확장자
+	 * @param movieId 생성된 Movie ID
+	 * @return 생성 될 파일 이름
+	 */
+	private String generateNewFileName(String fullPath, String extension, Long movieId) {
+		return new StringBuilder(fullPath)
+			.append("/")
+			.append(movieId)
+			.append(extension)
+			.toString();
+	}
+
+	/**
+	 * 전달받은 파일의 확장자를 추출한다.
+	 * @param originalFileName 파일 명
+	 * @return 확장자
+	 */
+	private String getFileExtension(String originalFileName) {
+		String extension = "";
+		if (originalFileName != null && originalFileName.contains(FILE_EXTENSION_SEPARATOR)) {
+			extension = originalFileName.substring(originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR));
+		}
+		return extension;
+	}
+
+	/**
+	 * 로컬에 저장 할 디렉터리가 존재하지 않다면 생성
+	 * @param fullPath 디렉터리 경로
+	 */
+	private void makeDirectory(String fullPath) {
+		File dir = new File(fullPath);
+		if (!dir.exists()) {
+			dir.mkdirs();
+		}
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/config/S3Config.java
+++ b/src/main/java/prgrms/marco/be02marbox/config/S3Config.java
@@ -1,0 +1,32 @@
+package prgrms.marco.be02marbox.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
+++ b/src/main/java/prgrms/marco/be02marbox/domain/movie/service/MovieService.java
@@ -1,17 +1,13 @@
 package prgrms.marco.be02marbox.domain.movie.service;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
+import prgrms.marco.be02marbox.aws.S3Upload;
 import prgrms.marco.be02marbox.domain.movie.Movie;
 import prgrms.marco.be02marbox.domain.movie.dto.RequestCreateMovie;
 import prgrms.marco.be02marbox.domain.movie.repository.MovieRepository;
@@ -21,19 +17,19 @@ import prgrms.marco.be02marbox.domain.movie.service.utils.MovieConverter;
 public class MovieService {
 
 	private final MovieRepository movieRepository;
-
 	private final MovieConverter movieConverter;
-
-	private static final String posterDirectory = "posters";
+	private final S3Upload s3Upload;
 
 	public MovieService(MovieRepository movieRepository,
-		MovieConverter movieConverter) {
+		MovieConverter movieConverter, S3Upload s3Upload) {
 		this.movieRepository = movieRepository;
 		this.movieConverter = movieConverter;
+		this.s3Upload = s3Upload;
 	}
 
 	/**
 	 * movie 테이블에 영화 데이터를 추가한다
+	 * 포스터는 S3 저장소에 저장된다.
 	 *
 	 * @param
 	 *    requestCreateMovie: 사용자의 Movie 생성 요청
@@ -43,44 +39,8 @@ public class MovieService {
 	public Long createMovie(RequestCreateMovie requestCreateMovie) throws IOException {
 		Movie movie = movieConverter.convertFromRequestCreateMovieToMovie(requestCreateMovie);
 		Long movieId = movieRepository.save(movie).getId();
-		movie.updatePosterImgLocation(savePoster(requestCreateMovie.poster(), movieId));
+		movie.updatePosterImgLocation(s3Upload.upload(requestCreateMovie.poster(), movieId));
 		return movieId;
-	}
-
-	private String savePoster(MultipartFile poster, Long movieId) throws IOException {
-		makeDirectory();
-
-		String posterPath = generateNewFileName(poster, movieId);
-		File posterFile = new File(posterPath);
-
-		InputStream initialStream = poster.getInputStream();
-		byte[] buffer = new byte[initialStream.available()];
-		initialStream.read(buffer);
-
-		try (OutputStream outputStream = new FileOutputStream(posterFile)) {
-			outputStream.write(buffer);
-		}
-
-		return posterPath;
-	}
-
-	private String generateNewFileName(MultipartFile poster, Long movieId) {
-		return new StringBuilder(posterDirectory)
-			.append("/")
-			.append(movieId)
-			.append(getFileExtension(poster.getOriginalFilename()))
-			.toString();
-	}
-
-	private String getFileExtension(String originalFileName) {
-		return originalFileName.substring(originalFileName.lastIndexOf('.'));
-	}
-
-	private void makeDirectory() {
-		File dir = new File(posterDirectory);
-		if (!dir.exists()) {
-			dir.mkdir();
-		}
 	}
 
 	/**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,10 +17,21 @@ spring:
     show-sql: true
     open-in-view: false
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
 logging:
   level:
     root: debug
   config: classpath:logback-${spring.config.activate.on-profile}.xml
+
+cloud:
+  aws:
+    s3:
+      bucket: marbox-bucket
+      save-dir-prefix: dev/
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -24,3 +24,13 @@ logging:
   config: classpath:logback-${spring.config.activate.on-profile}.xml
   level:
     root: info
+
+cloud:
+  aws:
+    s3:
+      bucket: marbox-bucket
+      save-dir-prefix: test/
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     default: dev
+    include: aws
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher

--- a/src/test/java/prgrms/marco/be02marbox/domain/movie/service/MovieServiceTest.java
+++ b/src/test/java/prgrms/marco/be02marbox/domain/movie/service/MovieServiceTest.java
@@ -5,28 +5,27 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.mock.web.MockMultipartFile;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+
+import prgrms.marco.be02marbox.aws.S3Upload;
 import prgrms.marco.be02marbox.domain.movie.Genre;
 import prgrms.marco.be02marbox.domain.movie.LimitAge;
 import prgrms.marco.be02marbox.domain.movie.Movie;
-import prgrms.marco.be02marbox.domain.movie.dto.RequestCreateMovie;
 import prgrms.marco.be02marbox.domain.movie.repository.MovieRepository;
 import prgrms.marco.be02marbox.domain.movie.service.utils.MovieConverter;
 
 @DataJpaTest
-@Import({MovieService.class, MovieConverter.class})
+@Import({MovieService.class, MovieConverter.class, S3Upload.class, AmazonS3Client.class})
 class MovieServiceTest {
 
 	@Autowired
@@ -35,53 +34,27 @@ class MovieServiceTest {
 	@Autowired
 	MovieRepository movieRepository;
 
-	static RequestCreateMovie frozen;
-	static RequestCreateMovie notebook;
-	static RequestCreateMovie matrix;
-	static RequestCreateMovie tangled;
-	static RequestCreateMovie tazza;
-	static RequestCreateMovie aboutTime;
+	@PersistenceContext
+	EntityManager em;
 
-
-	@BeforeAll
-	static void beforeAll() {
-		frozen = new RequestCreateMovie("Frozen", LimitAge.CHILD, Genre.ANIMATION, 102,
-			new MockMultipartFile("fronzen.tmp", "fronzen.tmp", "tmp", "fronzen poster".getBytes()));
-		notebook = new RequestCreateMovie("NoteBook", LimitAge.CHILD, Genre.ROMANCE, 124,
-			new MockMultipartFile("notebook.tmp", "notebook.tmp", "tmp", "notebook poster".getBytes()));
-		matrix = new RequestCreateMovie("Matrix", LimitAge.CHILD, Genre.ACTION, 136,
-			new MockMultipartFile("matrix.tmp", "matrix.tmp", "tmp", "matrix poster".getBytes()));
-		tangled = new RequestCreateMovie("tangled", LimitAge.CHILD, Genre.ANIMATION, 148,
-			new MockMultipartFile("tangled.tmp", "tangled.tmp", "tmp", "tangled poster".getBytes()));
-		tazza = new RequestCreateMovie("tazza", LimitAge.ADULT, Genre.ACTION, 186,
-			new MockMultipartFile("tazza.tmp", "tazza.tmp", "tmp", "tazza poster".getBytes()));
-		aboutTime = new RequestCreateMovie("About Time", LimitAge.CHILD, Genre.ROMANCE, 124,
-			new MockMultipartFile("about_time.tmp", "about_time.tmp", "tmp", "about time poster".getBytes()));
-	}
-
-	@Test
-	@DisplayName("movie를 추가할 수 있다")
-	void testCreateMovie() throws IOException {
-		Long movieId = movieService.createMovie(frozen);
-		Optional<Movie> found = movieRepository.findById(movieId);
-		assertAll(
-			() -> assertThat(found.isPresent()).isTrue(),
-			() -> assertThat(found.get().getName()).isEqualTo(frozen.name()),
-			() -> assertThat(found.get().getLimitAge()).isEqualTo(frozen.limitAge()),
-			() -> assertThat(found.get().getGenre()).isEqualTo(frozen.genre()),
-			() -> assertThat(found.get().getRunningTime()).isEqualTo(frozen.runningTime())
-		);
-	}
+	Movie frozen = new Movie("Frozen", LimitAge.CHILD, Genre.ANIMATION, 102);
+	Movie notebook = new Movie("NoteBook", LimitAge.CHILD, Genre.ROMANCE, 124);
+	Movie matrix = new Movie("Matrix", LimitAge.CHILD, Genre.ACTION, 136);
+	Movie tangled = new Movie("tangled", LimitAge.CHILD, Genre.ANIMATION, 148);
+	Movie tazza = new Movie("tazza", LimitAge.ADULT, Genre.ACTION, 186);
+	Movie aboutTime = new Movie("About Time", LimitAge.CHILD, Genre.ROMANCE, 124);
 
 	@Test
 	@DisplayName("movie 리스트를 조회할 수 있다")
-	void testGetMovies() throws IOException {
-		movieService.createMovie(frozen);
-		movieService.createMovie(notebook);
-		movieService.createMovie(matrix);
-		movieService.createMovie(tangled);
-		movieService.createMovie(tazza);
-		movieService.createMovie(aboutTime);
+	void testGetMovies() {
+		movieRepository.save(frozen);
+		movieRepository.save(notebook);
+		movieRepository.save(matrix);
+		movieRepository.save(tangled);
+		movieRepository.save(tazza);
+		movieRepository.save(aboutTime);
+		em.flush();
+		em.clear();
 
 		List<Movie> movies1 = movieService.getMovies(0, 5);
 		List<Movie> movies2 = movieService.getMovies(1, 5);
@@ -90,7 +63,7 @@ class MovieServiceTest {
 		assertAll(
 			() -> assertThat(movies1).hasSize(5),
 			() -> assertThat(movies2).hasSize(1),
-			() -> assertThat(movies3).hasSize(0)
+			() -> assertThat(movies3).isEmpty()
 		);
 	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,3 +31,18 @@ jwt:
   issuer: testIssuer
   client-secret: lsuvomkeoiotkbzdjrejfgdsfngusviykzsvjoriyukscpmxiijmpfsdwveljsml
   expiry-seconds: 100
+
+cloud:
+  aws:
+    s3:
+      bucket: marbox-bucket
+      save-dir-prefix: temp/
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+    credentials:
+      instance-profile: true
+      access-key:
+      secret-key:


### PR DESCRIPTION
## 개요
- 파일 업로드 S3 연동

## 추가기능
- 무비 등록시 포스터는 S3에 저장된다.

## 변경사항(Optional)
- AWS S3 버킷 추가
- MovieService.save 로직 변경
  - 파일이 S3로 저장되면서, save관련 테스트코드 제거
- S3 관련 properties 추가 (application-dev, application-test)
  - profile마다 저장되는 경로가 다르게 설정.

## 사용방법(Optional)
- dev환경에서 저장하기 위해서는 `application-aws.yml`이 필요하다.
  - 해당 설정파일에는 access-key, secert-key 정보가 등록되어있다. 보안을 위해 github에는 push하지 않음.
  - ec2에는 관련 설정정보를 직접 추가 함.