### PR TITLE
[#203] Jacoco 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'java'
     id 'checkstyle'
     id 'com.epages.restdocs-api-spec' version '0.16.0'
+    id 'jacoco'
 }
 
 group = 'prgrms.marco'
@@ -23,6 +24,37 @@ checkstyle {
 
 ext {
     set('snippetsDir', file("build/generated-snippets"))
+}
+
+jacoco {
+    toolVersion = '0.8.7'
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled(true)
+        xml.enabled(false)
+        csv.enabled(false)
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'BUNDLE'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            excludes = []
+        }
+    }
 }
 
 dependencies {
@@ -59,6 +91,8 @@ dependencies {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+
+    finalizedBy 'jacocoTestReport'
 }
 
 tasks.named('asciidoctor') {


### PR DESCRIPTION
## 개요
- Jacoco 도입

## 추가기능
- 빌드시 테스트 커버리지 (라인기준) 80프로 넘겨야 성공

## 기타
- 예시
<img width="1808" alt="jacoco" src="https://user-images.githubusercontent.com/29492667/178914396-5fd46d7c-62de-451b-8bc3-a982bb65f6ae.png">
- report 위치
<img width="665" alt="스크린샷 2022-07-14 오후 3 19 53" src="https://user-images.githubusercontent.com/29492667/178914469-52dda260-48b8-4cf0-b502-968c7f2004d8.png">

